### PR TITLE
refactor: reduce duplication in scripts

### DIFF
--- a/forecast.rb
+++ b/forecast.rb
@@ -1,40 +1,18 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'bundler'
-Bundler.setup
-
-require 'erb'
-require 'excon'
-require 'fileutils'
-require 'json'
-
-require './lib/provider'
-require './lib/response'
-require './lib/metaculus'
-require './lib/prompts'
-require './lib/utility'
+require_relative 'lib/script_helpers'
 
 FORECASTERS = Provider::FORECASTERS
 
-# metaculus test questions: (binary: 578, numeric: 14333, multiple-choice: 22427, discrete: 38880)
 post_id = ARGV[0] || raise('post id argv[0] is required')
 forecaster_index = ARGV[1]&.to_i || raise('forecaster index argv[1] is required')
-init_cache(post_id)
 
-post_json = Metaculus.get_post(post_id).to_json
-cache_write(post_id, 'post.json', post_json)
-question = Metaculus::Question.new(data: JSON.parse(post_json))
-if question.existing_forecast? && !%w[578 14333 22427 38880].include?(post_id)
-  Formatador.display "\n[bold][green]# Skipping: Already Submitted Forecast for #{post_id}[/] "
-  exit
-end
+question = fetch_question(post_id)
+exit if should_skip_forecast?(question, post_id)
 
 cache_write(post_id, 'inputs/system.superforecaster.md', SUPERFORECASTER_SYSTEM_PROMPT)
-
-research_json = cache_read!(post_id, 'research.json')
-research = Response.new(:perplexity, json: research_json)
-@research_output = research.stripped_content('reflect')
+@research_output = load_research(post_id, strip_tags: 'reflect')
 
 provider = FORECASTERS[forecaster_index]
 Formatador.display "\n[bold][green]# Superforecaster[#{forecaster_index}: #{provider}]: Forecasting(#{post_id})…[/] "

--- a/forecast_result.rb
+++ b/forecast_result.rb
@@ -1,30 +1,15 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'bundler'
-Bundler.setup
-
-require 'erb'
-require 'excon'
-require 'fileutils'
-require 'json'
-
-require './lib/provider'
-require './lib/response'
-require './lib/metaculus'
-require './lib/prompts'
-require './lib/utility'
+require_relative 'lib/script_helpers'
 
 FORECASTERS = Provider::FORECASTERS
 
-# metaculus test questions: (binary: 578, numeric: 14333, multiple-choice: 22427, discrete: 38880)
 post_id = ARGV[0] || raise('post id argv[0] is required')
 forecaster_index = ARGV[1].to_i || raise('forecaster_index argv[1] is required')
 type = ARGV[2] || raise('type argv[2] is required')
-init_cache(post_id)
 
-post_json = cache_read!(post_id, 'post.json')
-question = Metaculus::Question.new(data: JSON.parse(post_json))
+question = load_cached_question(post_id)
 
 forecast_json = cache_read!(post_id, "forecasts/#{type}.#{forecaster_index}.json")
 provider = FORECASTERS[forecaster_index]

--- a/lib/script_helpers.rb
+++ b/lib/script_helpers.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Common requires for all scripts
+require 'bundler'
+Bundler.setup
+
+require 'erb'
+require 'excon'
+require 'fileutils'
+require 'json'
+
+require_relative 'provider'
+require_relative 'response'
+require_relative 'metaculus'
+require_relative 'prompts'
+require_relative 'utility'

--- a/news.rb
+++ b/news.rb
@@ -1,34 +1,18 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'bundler'
-Bundler.setup
-
-require 'erb'
-require 'excon'
-require 'fileutils'
-require 'json'
-
+require_relative 'lib/script_helpers'
 require './lib/anthropic'
 require './lib/asknews'
 require './lib/deepseek'
-require './lib/metaculus'
 require './lib/openai'
 require './lib/perplexity'
-require './lib/prompts'
-require './lib/utility'
 
-# metaculus test questions: (binary: 578, numeric: 14333, multiple-choice: 22427, discrete: 38880)
 post_id = ARGV[0] || raise('post id argument is required')
-init_cache(post_id)
 
-Formatador.display "\n[bold][green]# Metaculus: Getting Post(#{post_id})…[/] "
-post_json = Metaculus.get_post(post_id).to_json
-cache_write(post_id, 'post.json', post_json)
-question = Metaculus::Question.new(data: JSON.parse(post_json))
-
-if question.existing_forecast? && !%w[578 14333 22427 38880].include?(post_id)
-  Formatador.display "\n[bold][green]# Skipping: Already Submitted Forecast for #{post_id}[/] "
+question = fetch_question(post_id)
+if should_skip_forecast?(question, post_id)
+  # Commented out exit to allow news gathering for already-forecasted questions
   # exit
 end
 

--- a/research.rb
+++ b/research.rb
@@ -1,34 +1,15 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'bundler'
-Bundler.setup
-
-require 'erb'
-require 'excon'
-require 'fileutils'
-require 'json'
-
+require_relative 'lib/script_helpers'
 require './lib/anthropic'
-require './lib/metaculus'
 require './lib/openai'
 require './lib/perplexity'
-require './lib/prompts'
-require './lib/utility'
 
-# metaculus test questions: (binary: 578, numeric: 14333, multiple-choice: 22427, discrete: 38880)
 post_id = ARGV[0] || raise('post id argument is required')
-init_cache(post_id)
 
-Formatador.display "\n[bold][green]# Metaculus: Getting Post(#{post_id})…[/] "
-post_json = Metaculus.get_post(post_id).to_json
-cache_write(post_id, 'post.json', post_json)
-question = Metaculus::Question.new(data: JSON.parse(post_json))
-
-if question.existing_forecast? && !%w[578 14333 22427 38880].include?(post_id)
-  Formatador.display "\n[bold][green]# Skipping: Already Submitted Forecast for #{post_id}[/] "
-  exit
-end
+question = fetch_question(post_id)
+exit if should_skip_forecast?(question, post_id)
 
 cache_write(post_id, 'inputs/system.researcher.md', RESEARCHER_SYSTEM_PROMPT)
 

--- a/review_research.rb
+++ b/review_research.rb
@@ -1,34 +1,15 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'bundler'
-Bundler.setup
-
-require 'erb'
-require 'excon'
-require 'fileutils'
-require 'json'
-
-require './lib/provider'
-require './lib/response'
-require './lib/metaculus'
-require './lib/prompts'
-require './lib/utility'
+require_relative 'lib/script_helpers'
 
 FORECASTERS = Provider::FORECASTERS
 
-# metaculus test questions: (binary: 578, numeric: 14333, multiple-choice: 22427, discrete: 38880)
 post_id = ARGV[0] || raise('post id argument is required')
 forecaster_index = ARGV[1]&.to_i || raise('forecaster index argv[1] is required')
-init_cache(post_id)
 
-post_json = Metaculus.get_post(post_id).to_json
-cache_write(post_id, 'post.json', post_json)
-question = Metaculus::Question.new(data: JSON.parse(post_json))
-if question.existing_forecast? && !%w[578 14333 22427 38880].include?(post_id)
-  Formatador.display "\n[bold][green]# Skipping: Already Submitted Forecast for #{post_id}[/] "
-  exit
-end
+question = fetch_question(post_id)
+exit if should_skip_forecast?(question, post_id)
 
 research_json = cache_read!(post_id, 'research.json')
 research = Response.new(:perplexity, json: research_json)

--- a/revise_forecast.rb
+++ b/revise_forecast.rb
@@ -1,44 +1,18 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'bundler'
-Bundler.setup
-
-require 'erb'
-require 'excon'
-require 'fileutils'
-require 'json'
-
-require './lib/provider'
-require './lib/response'
-require './lib/metaculus'
-require './lib/prompts'
-require './lib/utility'
+require_relative 'lib/script_helpers'
 
 FORECASTERS = Provider::FORECASTERS
 
-# metaculus test questions: (binary: 578, numeric: 14333, multiple-choice: 22427, discrete: 38880)
 post_id = ARGV[0] || raise('post id argument is required')
 forecaster_index = ARGV[1]&.to_i || raise('forecaster index argv[1] is required')
-init_cache(post_id)
 
-post_json = Metaculus.get_post(post_id).to_json
-cache_write(post_id, 'post.json', post_json)
-question = Metaculus::Question.new(data: JSON.parse(post_json))
-if question.existing_forecast? && !%w[578 14333 22427 38880].include?(post_id)
-  Formatador.display "\n[bold][green]# Skipping: Already Submitted Forecast for #{post_id}[/] "
-  exit
-end
+question = fetch_question(post_id)
+exit if should_skip_forecast?(question, post_id)
 
-research_json = cache_read!(post_id, 'research.json')
-research = Response.new(:perplexity, json: research_json)
-@research_output = research.stripped_content('reflect')
-
-@forecasts = []
-FORECASTERS.each_with_index do |provider, index|
-  forecast_json = cache_read!(post_id, "forecasts/forecast.#{index}.json")
-  @forecasts << Response.new(provider, json: forecast_json)
-end
+@research_output = load_research(post_id, strip_tags: 'reflect')
+@forecasts = load_forecasts(post_id, type: 'forecast')
 
 provider = FORECASTERS[forecaster_index]
 @forecast = @forecasts[forecaster_index]


### PR DESCRIPTION
Add helper functions to eliminate repeated patterns:
- TestQuestions module with test question identity helpers
- Question loading helpers (fetch_question, load_cached_question)
- Forecast loading helpers (load_forecasts, load_forecast)
- Research loading helper (load_research)
- Script initialization helper (lib/script_helpers.rb)

Refactor 8 scripts to use new helpers:
- Reduce ~200 lines of duplication
- 35-53% reduction in boilerplate per script
- Single source of truth for common patterns


Change-ID: se793792791e65674k