### PR TITLE
Phase A: persist forecast records to git after consensus (closes #77)

### DIFF
--- a/.github/workflows/forecast.yml
+++ b/.github/workflows/forecast.yml
@@ -298,3 +298,69 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "$(cat tmp/${{ inputs.post_id }}/consensus/comment.json | jq -r '.text')" >> $GITHUB_STEP_SUMMARY
+
+  persist:
+    needs: consensus
+    if: ${{ inputs.post_id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/cache/restore@v5
+        with:
+          key:  tmp/${{ inputs.post_id }}/forecasts/forecast.0.json
+          path: tmp/${{ inputs.post_id }}/forecasts/forecast.0.json
+      - uses: actions/cache/restore@v5
+        with:
+          key:  tmp/${{ inputs.post_id }}/forecasts/forecast.1.json
+          path: tmp/${{ inputs.post_id }}/forecasts/forecast.1.json
+      - uses: actions/cache/restore@v5
+        with:
+          key:  tmp/${{ inputs.post_id }}/forecasts/forecast.2.json
+          path: tmp/${{ inputs.post_id }}/forecasts/forecast.2.json
+      - uses: actions/cache/restore@v5
+        with:
+          key:  tmp/${{ inputs.post_id }}/forecasts/forecast.3.json
+          path: tmp/${{ inputs.post_id }}/forecasts/forecast.3.json
+      - uses: actions/cache/restore@v5
+        with:
+          key:  tmp/${{ inputs.post_id }}/forecasts/revision.0.json
+          path: tmp/${{ inputs.post_id }}/forecasts/revision.0.json
+      - uses: actions/cache/restore@v5
+        with:
+          key:  tmp/${{ inputs.post_id }}/forecasts/revision.1.json
+          path: tmp/${{ inputs.post_id }}/forecasts/revision.1.json
+      - uses: actions/cache/restore@v5
+        with:
+          key:  tmp/${{ inputs.post_id }}/forecasts/revision.2.json
+          path: tmp/${{ inputs.post_id }}/forecasts/revision.2.json
+      - uses: actions/cache/restore@v5
+        with:
+          key:  tmp/${{ inputs.post_id }}/forecasts/revision.3.json
+          path: tmp/${{ inputs.post_id }}/forecasts/revision.3.json
+      - uses: actions/cache/restore@v5
+        with:
+          key:  tmp/${{ inputs.post_id }}/forecasts/consensus.json
+          path: tmp/${{ inputs.post_id }}/forecasts/consensus.json
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+      - run: bundle exec ruby persist_forecast.rb ${{ inputs.post_id }}
+        env:
+          METACULUS_BOT_API_TOKEN: ${{ secrets.METACULUS_BOT_API_TOKEN }}
+          METACULUS_BOT_ID: ${{ secrets.METACULUS_BOT_ID }}
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/unresolved/
+          git diff --cached --quiet && exit 0
+          git commit -m "[skip ci] Record forecast for ${{ inputs.post_id }}"
+          n=0
+          until [ $n -ge 4 ]; do
+            git pull --rebase origin main && git push origin main && exit 0
+            n=$((n+1))
+            sleep $((n * 2))
+          done
+          exit 1

--- a/lib/helpers/response.rb
+++ b/lib/helpers/response.rb
@@ -66,6 +66,10 @@ module ResponseHelpers
     strip_xml(content, *tags)
   end
 
+  def model
+    data['model']
+  end
+
   def to_json(*args)
     data.to_json(*args)
   end

--- a/lib/utility.rb
+++ b/lib/utility.rb
@@ -177,6 +177,20 @@ def load_forecasts(post_id, type: 'forecast', forecasters: Provider::FORECASTERS
   end
 end
 
+# Extract the forecast value from a Response for the given question type
+def forecast_value(response, question_type)
+  case question_type
+  when 'binary'
+    { probability: response.probability }
+  when 'numeric', 'discrete'
+    { percentiles: response.percentiles }
+  when 'multiple_choice'
+    { probabilities: response.probabilities }
+  else
+    {}
+  end
+end
+
 # Load a single forecast for a specific forecaster
 def load_forecast(post_id, forecaster_index, type: 'forecast', forecasters: Provider::FORECASTERS)
   provider = forecasters[forecaster_index]

--- a/persist_forecast.rb
+++ b/persist_forecast.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'lib/script_helpers'
+
+post_id = ARGV[0] || raise('post id argument is required')
+
+if TestQuestions.test_question?(post_id)
+  Formatador.display_line "\n[bold][yellow]# Persist: Skipping test question #{post_id}[/]"
+  exit
+end
+
+question = fetch_question(post_id)
+
+tournament_id = question.data.dig('projects', 'default_project', 'slug') ||
+                raise("Cannot determine tournament_id for post #{post_id}")
+
+output_path = "data/unresolved/#{tournament_id}/#{post_id}.json"
+
+if File.exist?(output_path)
+  Formatador.display_line "\n[bold][yellow]# Persist: Already exists, skipping #{output_path}[/]"
+  exit
+end
+
+Formatador.display "\n[bold][green]# Persist: Writing forecast record for #{post_id}…[/] "
+
+forecasters = Provider::FORECASTERS
+initial_forecasts = load_forecasts(post_id, type: 'forecast')
+revised_forecasts = load_forecasts(post_id, type: 'revision')
+
+consensus_json = cache_read!(post_id, 'forecasts/consensus.json')
+consensus = Response.new(:anthropic, json: consensus_json)
+
+community = question.data.dig('question', 'aggregations', 'recency_weighted', 'latest')
+scheduled_resolve_time = question.data.dig('question', 'scheduled_resolve_time')
+
+record = {
+  post_id: question.post_id,
+  tournament_id: tournament_id,
+  title: question.title,
+  question_type: question.type,
+  tags: (question.data['tags'] || []).map { |t| t.is_a?(Hash) ? t['name'] : t },
+  forecasted_at: Time.now.utc.iso8601,
+  scheduled_resolve_time: scheduled_resolve_time,
+  community_prediction_at_forecast: community,
+  consensus_forecast: forecast_value(consensus, question.type),
+  individual_forecasts: {
+    initial: initial_forecasts.each_with_index.map do |f, i|
+      { provider: forecasters[i].to_s, model: f.model }.merge(forecast_value(f, question.type))
+    end,
+    revised: revised_forecasts.each_with_index.map do |f, i|
+      { provider: forecasters[i].to_s, model: f.model }.merge(forecast_value(f, question.type))
+    end
+  }
+}
+
+FileUtils.mkdir_p(File.dirname(output_path))
+File.write(output_path, JSON.pretty_generate(record))
+Formatador.display_line "done."

--- a/test/persist_forecast_test.rb
+++ b/test/persist_forecast_test.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+# Helpers to build minimal Response JSON for each question type
+module ForecastFixtures
+  PERCENTILE_LINES = <<~PERCENTILES.strip
+    Percentile 5: 10
+    Percentile 10: 20
+    Percentile 20: 30
+    Percentile 25: 35
+    Percentile 30: 40
+    Percentile 40: 50
+    Percentile 50: 60
+    Percentile 60: 70
+    Percentile 70: 80
+    Percentile 75: 85
+    Percentile 80: 90
+    Percentile 90: 100
+    Percentile 95: 110
+  PERCENTILES
+
+  def binary_response(probability: '0.45', model: 'claude-opus-4-6')
+    Response.new(:anthropic, json: JSON.generate({
+      'model' => model,
+      'choices' => [{ 'message' => { 'content' => "<probability>#{probability}</probability>" } }]
+    }))
+  end
+
+  def numeric_response(model: 'claude-opus-4-6')
+    Response.new(:anthropic, json: JSON.generate({
+      'model' => model,
+      'choices' => [{ 'message' => { 'content' => "<percentiles>#{PERCENTILE_LINES}</percentiles>" } }]
+    }))
+  end
+
+  def multiple_choice_response(model: 'claude-opus-4-6')
+    probs = "Option A: 40%\nOption B: 35%\nOption C: 25%"
+    Response.new(:anthropic, json: JSON.generate({
+      'model' => model,
+      'choices' => [{ 'message' => { 'content' => "<probabilities>#{probs}</probabilities>" } }]
+    }))
+  end
+end
+
+class ForecastValueTest < Minitest::Test
+  include ForecastFixtures
+
+  # binary
+  def test_binary_returns_probability_key
+    result = forecast_value(binary_response, 'binary')
+    assert result.key?(:probability)
+  end
+
+  def test_binary_probability_is_clamped_float
+    result = forecast_value(binary_response(probability: '0.45'), 'binary')
+    assert_in_delta 0.45, result[:probability], 0.0001
+  end
+
+  def test_binary_probability_as_percentage_string
+    result = forecast_value(binary_response(probability: '45%'), 'binary')
+    assert_in_delta 0.45, result[:probability], 0.0001
+  end
+
+  # numeric / discrete
+  def test_numeric_returns_percentiles_key
+    result = forecast_value(numeric_response, 'numeric')
+    assert result.key?(:percentiles)
+  end
+
+  def test_numeric_percentiles_is_a_hash
+    result = forecast_value(numeric_response, 'numeric')
+    assert_kind_of Hash, result[:percentiles]
+  end
+
+  def test_numeric_percentiles_has_expected_keys
+    result = forecast_value(numeric_response, 'numeric')
+    assert_includes result[:percentiles].keys, 50
+  end
+
+  def test_discrete_also_returns_percentiles
+    result = forecast_value(numeric_response, 'discrete')
+    assert result.key?(:percentiles)
+  end
+
+  # multiple_choice
+  def test_multiple_choice_returns_probabilities_key
+    result = forecast_value(multiple_choice_response, 'multiple_choice')
+    assert result.key?(:probabilities)
+  end
+
+  def test_multiple_choice_probabilities_is_a_hash
+    result = forecast_value(multiple_choice_response, 'multiple_choice')
+    assert_kind_of Hash, result[:probabilities]
+  end
+
+  def test_multiple_choice_probabilities_sum_near_one
+    result = forecast_value(multiple_choice_response, 'multiple_choice')
+    total = result[:probabilities].values.sum
+    assert_in_delta 1.0, total, 0.01
+  end
+
+  # unknown type
+  def test_unknown_type_returns_empty_hash
+    result = forecast_value(binary_response, 'group_of_questions')
+    assert_equal({}, result)
+  end
+end
+
+class PersistRecordStructureTest < Minitest::Test
+  include ForecastFixtures
+
+  # Build a minimal fake record the same way persist_forecast.rb does,
+  # using only the components we can exercise without the API.
+  def setup
+    @binary = binary_response(model: 'claude-opus-4-6')
+    @numeric = numeric_response(model: 'gpt-4o')
+  end
+
+  def test_forecast_value_merged_with_provider_metadata
+    forecasters = [:anthropic, :openai, :perplexity, :deepseek]
+    forecasts = [binary_response, binary_response, binary_response, binary_response]
+
+    individual = forecasts.each_with_index.map do |f, i|
+      { provider: forecasters[i].to_s, model: f.model }.merge(forecast_value(f, 'binary'))
+    end
+
+    assert_equal 4, individual.length
+    individual.each do |entry|
+      assert entry.key?(:provider)
+      assert entry.key?(:model)
+      assert entry.key?(:probability)
+    end
+  end
+
+  def test_individual_forecasts_include_model_field
+    entry = { provider: 'anthropic', model: @binary.model }.merge(forecast_value(@binary, 'binary'))
+    assert_equal 'claude-opus-4-6', entry[:model]
+  end
+
+  def test_individual_forecasts_model_nil_when_absent
+    r = Response.new(:openai, json: JSON.generate({
+      'choices' => [{ 'message' => { 'content' => '<probability>0.5</probability>' } }]
+    }))
+    entry = { provider: 'openai', model: r.model }.merge(forecast_value(r, 'binary'))
+    assert_nil entry[:model]
+  end
+
+  def test_record_keys_are_complete
+    # Simulate what persist_forecast.rb assembles so structural regressions
+    # are caught here rather than discovered at runtime.
+    consensus = binary_response
+    forecasters = [:anthropic, :openai, :perplexity, :deepseek]
+    forecasts = Array.new(4) { binary_response }
+
+    record = {
+      post_id: 12345,
+      tournament_id: 'fall-aib-2025',
+      title: 'Will X happen?',
+      question_type: 'binary',
+      tags: ['politics'],
+      forecasted_at: Time.now.utc.iso8601,
+      scheduled_resolve_time: '2026-06-30T00:00:00Z',
+      community_prediction_at_forecast: nil,
+      consensus_forecast: forecast_value(consensus, 'binary'),
+      individual_forecasts: {
+        initial: forecasts.each_with_index.map { |f, i| { provider: forecasters[i].to_s, model: f.model }.merge(forecast_value(f, 'binary')) },
+        revised: forecasts.each_with_index.map { |f, i| { provider: forecasters[i].to_s, model: f.model }.merge(forecast_value(f, 'binary')) }
+      }
+    }
+
+    %i[post_id tournament_id title question_type tags forecasted_at
+       scheduled_resolve_time community_prediction_at_forecast
+       consensus_forecast individual_forecasts].each do |key|
+      assert record.key?(key), "record missing key: #{key}"
+    end
+
+    assert record[:individual_forecasts].key?(:initial)
+    assert record[:individual_forecasts].key?(:revised)
+    assert_equal 4, record[:individual_forecasts][:initial].length
+    assert_equal 4, record[:individual_forecasts][:revised].length
+  end
+end
+
+class TestQuestionsSkipTest < Minitest::Test
+  def test_known_binary_test_id_is_skipped
+    assert TestQuestions.test_question?('578')
+  end
+
+  def test_known_numeric_test_id_is_skipped
+    assert TestQuestions.test_question?('14333')
+  end
+
+  def test_known_multiple_choice_test_id_is_skipped
+    assert TestQuestions.test_question?('22427')
+  end
+
+  def test_known_discrete_test_id_is_skipped
+    assert TestQuestions.test_question?('38880')
+  end
+
+  def test_real_question_id_is_not_skipped
+    refute TestQuestions.test_question?('99999')
+  end
+
+  def test_accepts_integer_post_id
+    assert TestQuestions.test_question?(578)
+  end
+end

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class ResponseModelTest < Minitest::Test
+  def response_with(json_data)
+    Response.new(:anthropic, json: JSON.generate(json_data))
+  end
+
+  def base_json(content: '', model: nil)
+    data = { 'choices' => [{ 'message' => { 'content' => content } }] }
+    data['model'] = model if model
+    data
+  end
+
+  def test_model_returns_model_string
+    r = response_with(base_json(model: 'claude-opus-4-6'))
+    assert_equal 'claude-opus-4-6', r.model
+  end
+
+  def test_model_returns_nil_when_absent
+    r = response_with(base_json)
+    assert_nil r.model
+  end
+
+  def test_model_returns_openai_model_string
+    r = response_with(base_json(model: 'gpt-4o'))
+    assert_equal 'gpt-4o', r.model
+  end
+end

--- a/test/run_tests.rb
+++ b/test/run_tests.rb
@@ -2,3 +2,5 @@
 # Single entry point to run all tests. Usage: bundle exec ruby test/run_tests.rb
 
 require_relative 'test_helper'
+require_relative 'response_test'
+require_relative 'persist_forecast_test'


### PR DESCRIPTION
## Summary

Rebases #77 onto main and adds a unit test suite for the new record-keeping code.

**Changes from #77:**
- `persist_forecast.rb` — after consensus, writes a structured JSON record to `data/unresolved/<tournament_id>/<post_id>.json`; skips test question IDs and is idempotent (no-op if file already exists)
- `lib/helpers/response.rb` — adds `Response#model` returning `data['model']`
- `.github/workflows/forecast.yml` — adds a `persist` job that runs after `consensus`, restores all forecast/revision/consensus caches, runs the script, and commits with `[skip ci]`; push retries up to 4× with rebase to handle concurrent jobs

**Added for testability:**
- `forecast_value(response, question_type)` extracted from the script body into `lib/utility.rb`

## Record format

```json
{
  "post_id": 12345,
  "tournament_id": "fall-aib-2025",
  "title": "Will X happen?",
  "question_type": "binary",
  "tags": [...],
  "forecasted_at": "2026-03-29T12:00:00Z",
  "scheduled_resolve_time": "2026-06-30T00:00:00Z",
  "community_prediction_at_forecast": { ... },
  "consensus_forecast": { "probability": 0.45 },
  "individual_forecasts": {
    "initial": [{ "provider": "anthropic", "model": "claude-opus-4-6", "probability": 0.40 }, ...],
    "revised":  [{ "provider": "anthropic", "model": "claude-opus-4-6", "probability": 0.43 }, ...]
  }
}
```

## Tests (24 passing)

| File | Coverage |
|---|---|
| `test/response_test.rb` | `Response#model` — present, absent, different provider strings |
| `test/persist_forecast_test.rb` | `forecast_value` for all 4 question types + unknown type; record key completeness; provider/model metadata in individual forecasts; `TestQuestions.test_question?` for all test IDs, real IDs, and integer input |

## Test plan

- [ ] `ruby persist_forecast.rb 578` (after full pipeline through consensus) — exits early with skip message (test question)
- [ ] `ruby persist_forecast.rb <real_post_id>` — creates `data/unresolved/<tournament>/<post_id>.json`
- [ ] Run again — exits early with "Already exists, skipping" (idempotent)
- [ ] Trigger a full tournament workflow run — confirm `persist` job succeeds and commits a file

Closes #20 (Phase A)

https://claude.ai/code/session_01NrVoGQc1NJzM4waUUFcaSH