### PR TITLE
Add RuboCop linting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4'
+          ruby-version: '4.0'
           bundler-cache: true
       - run: bundle exec rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,13 @@ jobs:
           ruby-version: '4.0'
           bundler-cache: true
       - run: bundle exec rake test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+      - run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-yard
 
 AllCops:
-  TargetRubyVersion: 3.4
+  TargetRubyVersion: 4.0
   NewCops: enable
 
 Layout/LineLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,23 @@
+require:
+  - rubocop-minitest
+  - rubocop-rake
+
+AllCops:
+  TargetRubyVersion: 3.4
+  NewCops: enable
+
+Layout/LineLength:
+  Max: 120
+  AllowedPatterns:
+    - '^\s*#'  # comments
+    - '^\s*[A-Z_]+ = '  # long string constants / heredocs
+
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'
+
+Metrics/MethodLength:
+  Max: 20
+
+Style/Documentation:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,5 +19,3 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Max: 20
 
-Style/Documentation:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-minitest
   - rubocop-rake
   - rubocop-yard

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-minitest
   - rubocop-rake
+  - rubocop-yard
 
 AllCops:
   TargetRubyVersion: 3.4

--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,5 @@ group :lint do
   gem 'rubocop'
   gem 'rubocop-minitest'
   gem 'rubocop-rake'
+  gem 'rubocop-yard'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,9 @@ group :test do
   gem 'mutex_m'
   gem 'rake'
 end
+
+group :lint do
+  gem 'rubocop'
+  gem 'rubocop-minitest'
+  gem 'rubocop-rake'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.3)
     drb (2.2.3)
     erb (6.0.2)
     excon (1.4.2)
@@ -8,16 +9,56 @@ GEM
     formatador (1.2.3)
       reline
     io-console (0.8.1)
+    json (2.19.3)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     logger (1.7.0)
     minitest (6.0.2)
       drb (~> 2.0)
       prism (~> 1.5)
     mutex_m (0.3.0)
+    parallel (1.27.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
     prism (1.9.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.2.1)
+    regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
+    rubocop (1.86.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-minitest (0.39.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+    rubocop-rake (0.7.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1)
+    rubocop-yard (1.1.0)
+      lint_roller
+      rubocop (~> 1.72)
+      yard
+    ruby-progressbar (1.13.0)
     rubyzip (3.2.2)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    yard (0.9.38)
 
 PLATFORMS
   ruby
@@ -30,6 +71,10 @@ DEPENDENCIES
   minitest
   mutex_m
   rake
+  rubocop
+  rubocop-minitest
+  rubocop-rake
+  rubocop-yard
   rubyzip
 
 RUBY VERSION

--- a/consensus.rb
+++ b/consensus.rb
@@ -22,7 +22,7 @@ begin
     llm = Provider.new(provider, system: CONSENSUS_SYSTEM_PROMPT, reasoning: { effort: 'high' })
     consensus_prompt = consensus_prompt_with_type(llm, question, FORECAST_CONSENSUS_PROMPT_TEMPLATE)
     cache_write(post_id, 'inputs/consensus.md', consensus_prompt)
-    consensus = llm.eval({ 'role': 'user', 'content': consensus_prompt })
+    consensus = llm.eval({ role: 'user', content: consensus_prompt })
     cache_write(post_id, 'outputs/consensus.md', consensus.content)
     consensus.to_json
   end

--- a/ete.rb
+++ b/ete.rb
@@ -23,7 +23,11 @@ raise("Invalid post_id: #{post_id.inspect}") unless post_id.to_i.to_s == post_id
 
 system('./news.rb', post_id)
 system('./tools_research.rb', post_id)
-post_data = JSON.parse(File.read("tmp/#{post_id}/post.json")) rescue {}
+post_data = begin
+  JSON.parse(File.read("tmp/#{post_id}/post.json"))
+rescue StandardError
+  {}
+end
 puts post_data['title']
 puts post_data.dig('question', 'description')
 Provider::FORECASTERS.count.times do |forecaster_index|

--- a/forecast.rb
+++ b/forecast.rb
@@ -21,7 +21,7 @@ cache(post_id, "forecasts/forecast.#{forecaster_index}.json") do
   llm = Provider.new(provider, **llm_args)
   forecast_prompt = prompt_with_type(llm, question, SHARED_FORECAST_PROMPT_TEMPLATE)
   cache_write(post_id, "inputs/forecast.#{forecaster_index}.md", forecast_prompt)
-  forecast = llm.eval({ 'role': 'user', 'content': forecast_prompt })
+  forecast = llm.eval({ role: 'user', content: forecast_prompt })
   puts forecast.content
   cache_write(post_id, "outputs/forecast.#{forecaster_index}.md", forecast.content)
   forecast.to_json

--- a/lib/asknews.rb
+++ b/lib/asknews.rb
@@ -50,8 +50,8 @@ class AskNews
       'https://api.asknews.app',
       expects: 200,
       headers: {
-        'accept': 'application/json',
-        'authorization': "Bearer #{ENV['ASKNEWS_API_KEY']}",
+        accept: 'application/json',
+        authorization: "Bearer #{ENV.fetch('ASKNEWS_API_KEY', nil)}",
         'content-type': 'application/json'
       },
       idempotent: true,

--- a/lib/deepseek.rb
+++ b/lib/deepseek.rb
@@ -27,8 +27,8 @@ class DeepSeek
         model: model,
         messages: [
           {
-            'role': 'system',
-            'content': system
+            role: 'system',
+            content: system
           }
         ].concat(messages),
         temperature: temperature,
@@ -88,8 +88,8 @@ class DeepSeek
       'https://api.deepseek.com/chat/completions',
       expects: 200,
       headers: {
-        'accept': 'application/json',
-        'authorization': "Bearer #{ENV['DEEPSEEK_API_KEY']}",
+        accept: 'application/json',
+        authorization: "Bearer #{ENV.fetch('DEEPSEEK_API_KEY', nil)}",
         'content-type': 'application/json'
       },
       idempotent: true,

--- a/lib/helpers/response.rb
+++ b/lib/helpers/response.rb
@@ -66,7 +66,7 @@ module ResponseHelpers
     strip_xml(content, *tags)
   end
 
-  def to_json(*args)
-    data.to_json(*args)
+  def to_json(*)
+    data.to_json(*)
   end
 end

--- a/lib/metaculus.rb
+++ b/lib/metaculus.rb
@@ -35,7 +35,7 @@ class Metaculus
       path: '/api/posts/',
       query: {
         forecast_type: %w[binary discrete multiple_choice numeric].join(','),
-        not_forecaster_id: ENV['METACULUS_BOT_ID'],
+        not_forecaster_id: ENV.fetch('METACULUS_BOT_ID', nil),
         include_description: true,
         offset: 0,
         statuses: 'open',
@@ -60,7 +60,7 @@ class Metaculus
       path: '/api/posts/',
       query: {
         forecast_type: %w[binary discrete multiple_choice numeric].join(','),
-        forecaster_id: ENV['METACULUS_BOT_ID'],
+        forecaster_id: ENV.fetch('METACULUS_BOT_ID', nil),
         include_description: true,
         limit: 100,
         statuses: 'resolved',
@@ -112,8 +112,8 @@ class Metaculus
       'https://www.metaculus.com',
       expects: 200,
       headers: {
-        'accept': 'application/json',
-        'authorization': "Token #{ENV['METACULUS_BOT_API_TOKEN']}",
+        accept: 'application/json',
+        authorization: "Token #{ENV.fetch('METACULUS_BOT_API_TOKEN', nil)}",
         'content-type': 'application/json'
       }
     )
@@ -137,7 +137,7 @@ class Metaculus
           options.each_with_index do |option, index|
             medians[option] = latest_aggregations['centers'][index] * 100
           end
-          content << "Medians: { #{medians.map { |k,v| format('"%s": %0.2f%%', k, v) }.join(', ')} }"
+          content << "Medians: { #{medians.map { |k, v| format('"%s": %0.2f%%', k, v) }.join(', ')} }"
         else
           units_string = units.empty? ? '' : " #{units}"
           if %w[discrete numeric].include?(type) && scaling['open_lower_bound']
@@ -197,7 +197,7 @@ class Metaculus
                          when 'multiple_choice'
                            # handled in aggregate_content
                          else
-                           (lower_bound + latest_aggregations['centers'].first * (upper_bound - lower_bound)).round(2)
+                           (lower_bound + (latest_aggregations['centers'].first * (upper_bound - lower_bound))).round(2)
                          end
     end
 
@@ -260,7 +260,7 @@ class Metaculus
           previous_y = data[previous_x]
           next_y = data[next_x]
 
-          y = previous_y + (x - previous_x) * (next_y - previous_y) / (next_x - previous_x)
+          y = previous_y + ((x - previous_x) * (next_y - previous_y) / (next_x - previous_x))
           y_values.append(y)
         end
       end
@@ -278,13 +278,13 @@ class Metaculus
         location = i / (y_values.length - 1)
         rescaled = (y - scale_lower_to) / rescaled_inbound_mass
         y_value = if scaling['open_lower_bound'] && scaling['open_upper_bound']
-                    0.988 * rescaled + 0.01 * location + 0.001
+                    (0.988 * rescaled) + (0.01 * location) + 0.001
                   elsif scaling['open_lower_bound']
-                    0.989 * rescaled + 0.01 * location + 0.001
+                    (0.989 * rescaled) + (0.01 * location) + 0.001
                   elsif scaling['open_upper_bound']
-                    0.989 * rescaled + 0.01 * location
+                    (0.989 * rescaled) + (0.01 * location)
                   else
-                    0.99 * rescaled + 0.01 * location
+                    (0.99 * rescaled) + (0.01 * location)
                   end
         # round to avoid floating point errors
         y_values[i] = y_value.round(10)
@@ -388,7 +388,7 @@ class Metaculus
       summation_y = points.map { |_, y| y }.sum
       summation_x2 = points.map { |x, _| x**2 }.sum
 
-      (n * summation_xy - summation_x * summation_y) / (n * summation_x2 - summation_x**2).to_f
+      ((n * summation_xy) - (summation_x * summation_y)) / ((n * summation_x2) - (summation_x**2)).to_f
     end
 
     def type
@@ -403,8 +403,8 @@ class Metaculus
       @upper_bound ||= scaling['nominal_max'] || scaling['range_max']
     end
 
-    def to_json(*args)
-      data.to_json(*args)
+    def to_json(*)
+      data.to_json(*)
     end
 
     private
@@ -414,9 +414,8 @@ class Metaculus
     end
 
     def latest_aggregations
-      @latest_aggregations ||= begin
-        data.dig('question', 'aggregations', 'recency_weighted', 'latest') || synced_question&.send(:latest_aggregations)
-      end
+      @latest_aggregations ||= data.dig('question', 'aggregations', 'recency_weighted',
+                                        'latest') || synced_question&.send(:latest_aggregations)
     end
 
     def question

--- a/lib/open_router.rb
+++ b/lib/open_router.rb
@@ -29,8 +29,8 @@ class OpenRouter
         model: model,
         messages: [
           {
-            'role': 'system',
-            'content': system
+            role: 'system',
+            content: system
           }
         ].concat(messages),
         reasoning: reasoning,
@@ -92,8 +92,8 @@ class OpenRouter
       'https://openrouter.ai/api/v1/chat/completions',
       expects: 200,
       headers: {
-        'accept': 'application/json',
-        'authorization': "Bearer #{ENV['OPEN_ROUTER_API_KEY']}",
+        accept: 'application/json',
+        authorization: "Bearer #{ENV.fetch('OPEN_ROUTER_API_KEY', nil)}",
         'content-type': 'application/json'
       },
       idempotent: true,

--- a/lib/perplexity.rb
+++ b/lib/perplexity.rb
@@ -24,8 +24,8 @@ class Perplexity
         model: model,
         messages: [
           {
-            'role': 'system',
-            'content': system
+            role: 'system',
+            content: system
           }
         ].concat(messages),
         temperature: temperature,
@@ -54,8 +54,8 @@ class Perplexity
       'https://api.perplexity.ai/chat/completions',
       expects: 200,
       headers: {
-        'accept': 'application/json',
-        'authorization': "Bearer #{ENV['PERPLEXITY_API_KEY']}",
+        accept: 'application/json',
+        authorization: "Bearer #{ENV.fetch('PERPLEXITY_API_KEY', nil)}",
         'content-type': 'application/json'
       },
       idempotent: true,

--- a/lib/tools.rb
+++ b/lib/tools.rb
@@ -72,7 +72,7 @@ module Tools
           - Generate research summaries that are concise while retaining necessary detail.
         SYSTEM
       llm.eval(
-        { 'role': 'user', 'content': prompt }
+        { role: 'user', content: prompt }
       )
     end
 

--- a/news.rb
+++ b/news.rb
@@ -51,7 +51,7 @@ filters_json = cache(post_id, 'news_filters.json') do
     system: '',
     tools: []
   )
-  filters = llm.eval({ 'role': 'user', 'content': filter_prompt })
+  filters = llm.eval({ role: 'user', content: filter_prompt })
   puts filters.content
   categories = filters.extracted_content('categories').split(', ')
   categories.select! { |category| CATEGORIES.include?(category) } # ignore category hallucinations

--- a/revise_forecast.rb
+++ b/revise_forecast.rb
@@ -25,9 +25,9 @@ cache(post_id, "forecasts/revision.#{forecaster_index}.json") do
   forecast_delphi_prompt = FORECAST_DELPHI_PROMPT_TEMPLATE.result(binding)
   cache_write(post_id, "inputs/revision.#{forecaster_index}.md", forecast_delphi_prompt)
   revision = llm.eval(
-    { 'role': 'user', 'content': forecast_prompt },
-    { 'role': 'assistant', 'content': @forecast.content },
-    { 'role': 'user', 'content': forecast_delphi_prompt }
+    { role: 'user', content: forecast_prompt },
+    { role: 'assistant', content: @forecast.content },
+    { role: 'user', content: forecast_delphi_prompt }
   )
   puts revision.content
   cache_write(post_id, "outputs/revision.#{forecaster_index}.md", revision.content)

--- a/summary.rb
+++ b/summary.rb
@@ -7,7 +7,7 @@ FORECASTERS = Provider::FORECASTERS
 
 post_id = ARGV[0] || raise('post id argv[0] is required')
 
-question = fetch_question(post_id)
+fetch_question(post_id)
 # exit if should_skip_forecast?(question, post_id)
 
 # cache_write(post_id, 'inputs/system.superforecaster.md', SUPERFORECASTER_SYSTEM_PROMPT)
@@ -28,7 +28,7 @@ prompt = <<~PROMPT
   </source>
 PROMPT
 puts prompt
-response = llm.eval({ 'role': 'user', 'content': prompt })
+response = llm.eval({ role: 'user', content: prompt })
 puts '---'
 puts response.content
 exit

--- a/test/run_tests.rb
+++ b/test/run_tests.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Single entry point to run all tests. Usage: bundle exec ruby test/run_tests.rb
 
 require_relative 'test_helper'

--- a/tools_research.rb
+++ b/tools_research.rb
@@ -24,7 +24,7 @@ cache(post_id, 'research.json') do
   @forecast_prompt = FORECAST_PROMPT_TEMPLATE.result(binding)
   @research_prompt = RESEARCH_PROMPT_TEMPLATE.result(binding)
   cache_write(post_id, 'inputs/research.md', @research_prompt)
-  research = llm.eval({ 'role': 'user', 'content': @research_prompt })
+  research = llm.eval({ role: 'user', content: @research_prompt })
   cache_write(post_id, 'outputs/research.md', research.content)
   research.to_json
 end

--- a/tournament_retro.rb
+++ b/tournament_retro.rb
@@ -28,18 +28,18 @@ provider = :deepseek
 llm = Provider.new(provider, system: '')
 
 retro_prompt = <<~RETRO_PROMPT
-I am participating in a forecasting tournament. Below are the titles of some of my recent forecasts and my score, where higher is better.
+  I am participating in a forecasting tournament. Below are the titles of some of my recent forecasts and my score, where higher is better.
 
-  <forecasts>
-  #{data.join.strip}
-  </forecasts>
+    <forecasts>
+    #{data.join.strip}
+    </forecasts>
 
-  Review this data, then:
-    - identify commonalities among the lowest and highest scores
-    - identify distinctions between highest and lowest scores
-    - recommend how lower scores could be improved upon (skipping questions is NOT an option)
-    - recommend how to improve this prompt to better analyze results and provide recommendations
+    Review this data, then:
+      - identify commonalities among the lowest and highest scores
+      - identify distinctions between highest and lowest scores
+      - recommend how lower scores could be improved upon (skipping questions is NOT an option)
+      - recommend how to improve this prompt to better analyze results and provide recommendations
 RETRO_PROMPT
 
-retro = llm.eval({ 'role': 'user', 'content': retro_prompt })
+retro = llm.eval({ role: 'user', content: retro_prompt })
 puts retro.content


### PR DESCRIPTION
- Add rubocop, rubocop-minitest, and rubocop-rake gems in a :lint group
- Add .rubocop.yml with TargetRubyVersion 3.4, relaxed line length (120),
  and Documentation cop disabled
- Add a lint job to ci.yml that runs bundle exec rubocop

https://claude.ai/code/session_013mjFZvBQjthGtcbzmgB9bE