### PR TITLE
fix(consensus): anchor synthesis to provided forecasts only

### DIFF
--- a/lib/prompt_templates/forecast_consensus.erb
+++ b/lib/prompt_templates/forecast_consensus.erb
@@ -10,10 +10,12 @@ Your consensus forecast will be based on the context of these forecasts from oth
 <%- end -%>
 </forecasts>
 
+Today is <%= Time.now.strftime('%B %d, %Y') %>.
+
 # Instructions
 
-- Before summarizing the consensus, identify the 2-3 largest divergences between the forecasts and explain which reasoning path is more epistemically sound and why.
-- Summarize the consensus of the forecasts.
-- Before summarizing the consensus, write:
-<%= SITUATION_SNAPSHOT -%>
-- After arriving at your consensus estimate, apply an extremization check: if the evidence strongly points in one direction, explicitly ask whether the consensus should be pushed further from 50%. State whether you are applying an extremization adjustment, by how much, and why. Only adjust if the cross-forecaster evidence genuinely warrants it — do not extremize mechanically.
+Work only from the forecasts provided above. Do not introduce independent analysis, base rates, or evidence not cited in the forecasts.
+
+- Identify the 2-3 largest divergences between the forecasts and explain which reasoning path is more epistemically sound and why, citing the forecasts directly.
+- Synthesize the forecasts into a consensus estimate, weighting by epistemic quality and stated confidence.
+- After arriving at your consensus estimate, apply an extremization check: if the forecasts consistently point in one direction, explicitly ask whether the consensus should be pushed further from 50%. State whether you are applying an extremization adjustment, by how much, and why. Only adjust if the cross-forecaster evidence genuinely warrants it — do not extremize mechanically.


### PR DESCRIPTION
## Summary

- Add current date injection to `forecast_consensus.erb` (matching `shared_forecast.erb`)
- Replace loose instructions that invited independent analysis with an explicit constraint to work only from the provided forecasts
- Remove the situation snapshot (it has no research/news context in consensus, causing the model to fill it in from its own knowledge)
- Reframe "summarize the consensus" as "synthesize the forecasts" to keep the model adjudicating between forecasters rather than re-deriving base rates

## Test plan

- [ ] Run consensus on a binary question and verify output stays grounded in the provided forecasts
- [ ] Run consensus on a numeric/multiple-choice question and verify no independent base rate derivation

🤖 Generated with [Claude Code](https://claude.com/claude-code)