### PR TITLE
Fix probability parsing when model omits percent sign

### DIFF
--- a/lib/helpers/response.rb
+++ b/lib/helpers/response.rb
@@ -44,7 +44,7 @@ module ResponseHelpers
       probabilities = {}
       extracted_content('probabilities').split("\n").each do |line|
         key, value = line.split(': ', 2)
-        probabilities[key] = value.include?('%') ? value.to_f / 100.0 : value.to_f
+        probabilities[key] = parse_probability(value)
       end
       probabilities
     end
@@ -52,12 +52,20 @@ module ResponseHelpers
 
   def probability
     @probability ||= begin
-      probability = extracted_content('probability')
-      probability = probability.include?('%') ? probability.to_f / 100.0 : probability.to_f
+      probability = parse_probability(extracted_content('probability'))
       clamped = probability.clamp(0.001, 0.999)
       warn "WARNING: probability #{probability} clamped to #{clamped}" if clamped != probability
       clamped
     end
+  end
+
+  # Parse a probability string that may be written as "45%", "45", or "0.45".
+  # A bare number greater than 1 is treated as a percentage so the model
+  # forgetting the % sign doesn't get clamped to 99.9%.
+  def parse_probability(text)
+    value = text.to_f
+    value /= 100.0 if text.include?('%') || value > 1.0
+    value
   end
 
   def stripped_content(*tags)

--- a/lib/prompts.rb
+++ b/lib/prompts.rb
@@ -51,7 +51,7 @@ BINARY_FORECAST_PROMPT = <<~BINARY_FORECAST_PROMPT
     - A plausible scenario resulting in a Yes outcome. Provide a brief narrative and estimate its likelihood, explaining how it contributes to your overall probability. For the 2-3 most critical assumption, estimate how much your probability distribution would change if it were false, and provide the revised probabilities.
   - At the end of your forecast, provide a single, precise final probability in the specified format.
     - Do not assign a probability below 5% or above 95% without extremely strong justification.
-    - Write your final prediction in this format:
+    - Write your final prediction in this format (the percent sign is required):
   <probability>
   X%
   </probability>
@@ -86,7 +86,7 @@ def multiple_choice_forecast_prompt(question)
       - A plausible scenario resulting in an unexpected outcome for each option. Provide a brief narrative and estimate its likelihood, explaining how it contributes to your overall probability. For the 2-3 most critical assumption, estimate how much your probability distribution would change if it were false, and provide the revised probabilities.
     - At the end of your forecast, provide precise, probabilistic final predictions for each option, only include the probability itself.
       - Predictions for each option must be between 0.1% and 99.9% and their sum must be 100%.
-      - Write your final predictions in this format:
+      - Write your final predictions in this format (the percent sign is required on every line):
     <probabilities>
     #{options_format}
     </probabilities>


### PR DESCRIPTION
The model occasionally writes <probability>28</probability> (no '%'). The
old parser fell through to value.to_f, returning 28.0, which clamp(0.001,
0.999) silently rounded down to 0.999 — submitting 99.9% while the comment
clearly argued for ~28%. Same pattern in multi-choice probabilities.

Treat any bare number greater than 1 as a percentage. Also reinforce in
the binary and multi-choice format prompts that the % sign is required.