### PR TITLE
Switch DeepSeek model from deepseek-reasoner to deepseek-v4-pro

### DIFF
--- a/lib/deepseek.rb
+++ b/lib/deepseek.rb
@@ -7,7 +7,7 @@ class DeepSeek
   attr_accessor :model, :system, :temperature, :tools
 
   def initialize(
-    model: 'deepseek-reasoner',
+    model: 'deepseek-v4-pro',
     system: SUPERFORECASTER_SYSTEM_PROMPT,
     temperature: 0.1,
     tools: []


### PR DESCRIPTION
## Summary
- Updates default DeepSeek model from legacy `deepseek-reasoner` to `deepseek-v4-pro`

## Test plan
- [ ] Run a forecast with the DeepSeek forecaster and verify it completes successfully: `ruby forecast.rb 578 3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)