### PR TITLE
Use Claude Opus 4.8 and drop stale OpenRouter default

### DIFF
--- a/lib/open_router.rb
+++ b/lib/open_router.rb
@@ -8,7 +8,7 @@ class OpenRouter
 
   def initialize(
     api_key: ENV['OPEN_ROUTER_API_KEY'],
-    model: 'anthropic/claude-sonnet-4.5',
+    model:,
     reasoning: { effort: 'medium' },
     system: SUPERFORECASTER_SYSTEM_PROMPT,
     temperature: 0.1,

--- a/lib/provider.rb
+++ b/lib/provider.rb
@@ -30,7 +30,7 @@ module Provider
 
       case provider_symbol
       when :anthropic
-        args[:model] ||= 'anthropic/claude-opus-4.6'
+        args[:model] ||= 'anthropic/claude-opus-4.8'
       when :openai
         args[:model] ||= 'openai/gpt-5.4'
         args[:api_key] ||= ENV['OPEN_ROUTER_OPENAI_API_KEY'] || ENV['OPEN_ROUTER_API_KEY']

--- a/tools_research.rb
+++ b/tools_research.rb
@@ -15,7 +15,7 @@ cache_write(post_id, 'inputs/system.researcher.md', RESEARCHER_SYSTEM_PROMPT)
 cache(post_id, 'research.json') do
   Formatador.display "\n[bold][green]# Researcher: Researching(#{post_id})…[/] "
   llm = OpenRouter.new(
-    model: 'anthropic/claude-opus-4.6',
+    model: 'anthropic/claude-opus-4.8',
     reasoning: { effort: 'high' },
     system: RESEARCHER_SYSTEM_PROMPT,
     tools: [SEARCH_TOOL]


### PR DESCRIPTION
## Summary
- Bump the Anthropic forecaster (`lib/provider.rb`) and research phase (`tools_research.rb`) models from `anthropic/claude-opus-4.6` → `anthropic/claude-opus-4.8`
- Confirmed `anthropic/claude-opus-4.8` is available on OpenRouter
- Remove the stale, unused `anthropic/claude-sonnet-4.5` default in `OpenRouter#initialize` — `model:` is now a required keyword since every call site already passes it explicitly

## Notes
The removed Sonnet default was never reachable at runtime: the only two `OpenRouter.new` call sites pass `model:` directly, and the `Provider` factory always assigns a model for both `:anthropic` and `:openai`. Making it required means a missing model now raises `ArgumentError` instead of silently falling back to an outdated model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)