### PR TITLE
Fix nil retries counter in JSON parse retry logic

### DIFF
--- a/lib/deepseek.rb
+++ b/lib/deepseek.rb
@@ -72,7 +72,7 @@ class DeepSeek
       self.eval(*messages)
     end
   rescue JSON::ParserError
-    retries = defined?(retries) ? retries + 1 : 1
+    retries = (retries || 0) + 1
     retry if retries <= 3
     raise
   rescue Excon::Error => e

--- a/lib/open_router.rb
+++ b/lib/open_router.rb
@@ -78,7 +78,7 @@ class OpenRouter
       self.eval(*messages)
     end
   rescue JSON::ParserError
-    retries = defined?(retries) ? retries + 1 : 1
+    retries = (retries || 0) + 1
     retry if retries <= 3
     raise
   rescue Excon::Error => e


### PR DESCRIPTION
## Problem

A run crashed with:

```
lib/open_router.rb:81:in 'OpenRouter#eval': undefined method '+' for nil (NoMethodError)
    retries = defined?(retries) ? retries + 1 : 1
```

This was triggered by a transient/truncated JSON response from the API (`unexpected end of input`), which should have been retried.

## Root cause

Classic Ruby `defined?` gotcha. When Ruby parses an assignment, it registers the assignment target (`retries`) as a local variable initialized to `nil` *before* the right-hand side runs. So `defined?(retries)` is already truthy on the very first rescue, taking the `retries + 1` branch — which becomes `nil + 1` and raises `NoMethodError`.

Because the error was raised *inside* the `rescue JSON::ParserError` block, it propagated up and crashed the run instead of retrying up to 3 times as intended.

## Fix

Replace with `retries = (retries || 0) + 1` so the first failure yields `1` and increments correctly thereafter. Applied in both `lib/open_router.rb` and `lib/deepseek.rb` (same pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)