### PR TITLE
Add tool/function-calling support to the Perplexity client (#122)

### DIFF
--- a/lib/deepseek.rb
+++ b/lib/deepseek.rb
@@ -51,19 +51,8 @@ class DeepSeek
     else
       messages.last['tool_calls'] = response.tool_calls
       response.tool_calls.each do |tool_call|
-        arguments = JSON.parse(tool_call.dig('function', 'arguments'))
-        tool = tool_call.dig('function', 'name')
-        content = case tool
-                  when 'search'
-                    Tools.search(arguments).content
-                  when 'think'
-                    Tools.think(arguments)
-                  else
-                    raise "Unknown Tool Requested: `#{tool}`"
-                  end
-
         messages << {
-          'content' => content,
+          'content' => Tools.dispatch(tool_call),
           'role' => 'tool',
           'tool_call_id' => tool_call['id']
         }

--- a/lib/open_router.rb
+++ b/lib/open_router.rb
@@ -57,19 +57,8 @@ class OpenRouter
     else
       messages.last['tool_calls'] = response.tool_calls
       response.tool_calls.each do |tool_call|
-        arguments = JSON.parse(tool_call.dig('function', 'arguments'))
-        tool = tool_call.dig('function', 'name')
-        content = case tool
-                  when 'search'
-                    Tools.search(arguments).content
-                  when 'think'
-                    Tools.think(arguments)
-                  else
-                    raise "Unknown Tool Requested: `#{tool}`"
-                  end
-
         messages << {
-          'content' => content,
+          'content' => Tools.dispatch(tool_call),
           'role' => 'tool',
           'tool_call_id' => tool_call['id']
         }

--- a/lib/perplexity.rb
+++ b/lib/perplexity.rb
@@ -1,46 +1,83 @@
 # frozen_string_literal: true
 
 require './lib/response'
+require './lib/tools'
 
 class Perplexity
-  attr_accessor :model, :system, :temperature
+  attr_accessor :model, :system, :temperature, :tools
 
   def initialize(
     model: 'sonar-reasoning-pro',
     system: RESEARCHER_SYSTEM_PROMPT,
-    temperature: 0.1
+    temperature: 0.1,
+    tools: []
   )
     @model = model
     @system = system
     @temperature = temperature
+    @tools = tools
   end
+
+  # NOTE: If a forecaster-Perplexity is given the `search` tool, calling it
+  # spawns a *second* Perplexity call (Tools.search instantiates its own
+  # Perplexity with model `sonar-pro`, native web_search_options).  This
+  # isn't infinite recursion but is an extra API round-trip.  For the
+  # forecast path, Perplexity should be handed only `submit_forecast` (and
+  # optionally `think`), **not** `search`.
 
   # https://docs.perplexity.ai/api-reference/chat-completions-post
   def eval(*messages)
     start_time = Time.now
-    excon_response = connection.post(
-      body: {
-        # max_tokens: 2048,
-        model: model,
-        messages: [
-          {
-            'role': 'system',
-            'content': system
-          }
-        ].concat(messages),
-        temperature: temperature,
-        web_search_options: {
-          search_context_size: 'medium'
+    body = {
+      model: model,
+      messages: [
+        {
+          'role': 'system',
+          'content': system
         }
-      }.to_json
-    )
+      ].concat(messages),
+      temperature: temperature
+    }
+
+    # Perplexity: native web_search_options and function-calling tools are
+    # mutually exclusive.  Send tools only when non-empty; otherwise keep
+    # the existing native search behavior for backward compatibility.
+    if tools.empty?
+      body[:web_search_options] = { search_context_size: 'medium' }
+    else
+      body[:tools] = tools
+    end
+
+    excon_response = connection.post(body: body.to_json)
     response = Response.new(
       :perplexity,
       duration: Time.now - start_time,
       json: excon_response.body
     )
-    response.display_meta
-    response
+    messages << {
+      'role' => 'assistant',
+      'content' => response.content,
+      'reasoning_content' => response.reasoning_content
+    }
+    if response.tool_calls.empty?
+      response.display_meta
+      response
+    else
+      messages.last['tool_calls'] = response.tool_calls
+      response.tool_calls.each do |tool_call|
+        messages << {
+          'content' => Tools.dispatch(tool_call),
+          'role' => 'tool',
+          'tool_call_id' => tool_call['id']
+        }
+      end
+
+      self.eval(*messages)
+    end
+  rescue JSON::ParserError
+    retries = (retries || 0) + 1
+    retry if retries <= 3
+    raise
   rescue Excon::Error => e
     puts e.message
     puts e.response.body

--- a/lib/tools.rb
+++ b/lib/tools.rb
@@ -81,5 +81,21 @@ module Tools
       Formatador.display_line "\n[bold][green]Thinking[faint](#{thoughts})[/]"
       'Thought thoughts.'
     end
+
+    # Shared tool-call dispatch.  Used by all tool-capable clients
+    # (OpenRouter, DeepSeek, Perplexity) so that tool routing stays in
+    # one place — especially important as #120 adds `submit_forecast`.
+    def dispatch(tool_call)
+      arguments = JSON.parse(tool_call.dig('function', 'arguments'))
+      tool = tool_call.dig('function', 'name')
+      case tool
+      when 'search'
+        search(arguments).content
+      when 'think'
+        think(arguments)
+      else
+        raise "Unknown Tool Requested: `#{tool}`"
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds function/tool-calling support to the `Perplexity` client so it can participate in tool-based flows on equal footing with `OpenRouter` and `DeepSeek`.

## Changes

### 1. `lib/tools.rb` — Shared dispatch helper
Extracted the duplicated tool-call dispatch block into `Tools.dispatch(tool_call)`. Centralizes tool routing (`search`, `think`) so that future additions like `submit_forecast` (#120) only need one change.

### 2. `lib/open_router.rb` — Uses `Tools.dispatch`
Replaced inline `case`/`when` with a single `Tools.dispatch(tool_call)` call.

### 3. `lib/deepseek.rb` — Uses `Tools.dispatch`
Same replacement as OpenRouter. The two clients now have identical tool-loop logic.

### 4. `lib/perplexity.rb` — Full tool/function-calling support
- Added `tools: []` to `initialize` and `attr_accessor :tools`
- Added `require './lib/tools'` for shared dispatch
- In `eval`: conditionally includes `tools` in the request body when non-empty; when empty, retains the existing `web_search_options` native search behavior for backward compatibility
- Added full tool-call dispatch + recursion loop (mirroring DeepSeek/OpenRouter)
- Added `JSON::ParserError` retry rescue (matching the other clients)
- Documented the `search`-tool-in-forecaster-Perplexity caveat

## API caveat findings

- **`web_search_options` + `tools`**: Mutually exclusive — `web_search_options` is gated off when tools are non-empty
- **Reasoning + tools**: `Response#openai_compatible_tool_calls` already extracts from `message.tool_calls` for Perplexity, so `sonar-reasoning-pro` tool calls are handled
- **Message-shape**: Perplexity's OpenAI-compatible endpoint accepts the standard `assistant` → `tool` role alternation

## Acceptance criteria

- [x] `Perplexity#eval` accepts and sends `tools`, and dispatches returned tool calls in a terminating loop
- [x] `Provider.new(:perplexity, tools: [...])` works without error
- [x] Existing tool-less Perplexity usage (`Tools.search`, research flow) is unchanged
- [x] Tool-call dispatch is shared across the three tool-capable clients
- [x] API caveats verified and documented

## Unblocks

- #120 (`submit_forecast`) for the Perplexity forecaster