### PR TITLE
Pre-compute time-remaining in templates (closes #125)

### DIFF
--- a/lib/metaculus.rb
+++ b/lib/metaculus.rb
@@ -319,11 +319,68 @@ class Metaculus
       @lower_bound ||= scaling['nominal_min'] || scaling['range_min']
     end
 
+    def resolve_time
+      ts = question['scheduled_resolve_time'] || question['actual_resolve_time']
+      ts && Time.parse(ts)
+    end
+
+    def placeholder_resolve?
+      rt = resolve_time
+      rt && rt.year >= 2099
+    end
+
+    def time_until_resolve
+      rt = resolve_time
+      return nil unless rt
+      return 'Already resolved' if rt <= Time.now
+      return 'No fixed resolution date' if placeholder_resolve?
+
+      days = ((rt - Time.now) / 86_400).floor
+      parts = ["#{days} day#{'s' unless days == 1}"]
+      years = (days / 365.25).round(1)
+      parts << "(≈ #{years} year#{'s' if years != 1})" if years >= 0.5
+      parts.join(' ')
+    end
+
+    def close_time
+      ts = question['scheduled_close_time'] || question['actual_close_time']
+      ts && Time.parse(ts)
+    end
+
+    def time_until_close
+      ct = close_time
+      return nil unless ct
+      return 'Already closed' if ct <= Time.now
+      days = ((ct - Time.now) / 86_400).floor
+      "#{days} day#{'s' unless days == 1}"
+    end
+
     def metadata_content
       @metadata_content ||= begin
         content = []
         asked_on = Time.parse(data['created_at'])
         content << "Asked On: #{asked_on.strftime('%B %d, %Y')}"
+
+        # Resolution date and time remaining
+        if (rt = resolve_time)
+          if placeholder_resolve?
+            content << "Scheduled Resolution: No fixed resolution date"
+          elsif rt <= Time.now
+            content << "Scheduled Resolution: #{rt.strftime('%B %d, %Y')} (Already resolved)"
+          else
+            content << "Scheduled Resolution: #{rt.strftime('%B %d, %Y')} (#{time_until_resolve})"
+          end
+        end
+
+        # Close date
+        if (ct = close_time)
+          if ct <= Time.now
+            content << "Forecasting Closes: #{ct.strftime('%B %d, %Y')} (Already closed)"
+          else
+            content << "Forecasting Closes: #{ct.strftime('%B %d, %Y')} (#{time_until_close})"
+          end
+        end
+
         unless lower_bound.nil?
           content << if scaling['open_lower_bound']
                        "Nominal Lower Bound: #{lower_bound}"
@@ -331,7 +388,7 @@ class Metaculus
                        "Lower Bound: #{lower_bound}"
                      end
         end
-        content << "Units: #{units}" unless units.empty?
+        content << "Units: #{units}" unless units.nil? || units.empty?
         unless upper_bound.nil?
           content << if scaling['open_upper_bound']
                        "Nominal Upper Bound: #{upper_bound}"

--- a/lib/prompt_templates/_situation_snapshot.erb
+++ b/lib/prompt_templates/_situation_snapshot.erb
@@ -1,3 +1,3 @@
-- The time remaining before the outcome of the question will become known.
+- Time remaining until resolution: <%= question.time_until_resolve || 'see Question Metadata' %>
 - The status quo outcome if nothing changed.
 - The expectations of experts and markets.

--- a/lib/prompt_templates/shared_forecast.erb
+++ b/lib/prompt_templates/shared_forecast.erb
@@ -27,4 +27,4 @@ Before forming your probability estimate, complete each of these five steps expl
 
 - Form your own probability estimate from the research before consulting the community aggregates. State this independent estimate explicitly, then note whether the aggregates cause you to revise it and why.
 - Before your forecast, write:
-<%= SITUATION_SNAPSHOT -%>
+<%= SITUATION_SNAPSHOT.result(binding) -%>

--- a/lib/prompts.rb
+++ b/lib/prompts.rb
@@ -28,6 +28,7 @@ SUPERFORECASTER_SYSTEM_PROMPT = ERB.new(<<~SUPERFORECASTER_SYSTEM_PROMPT, trim_m
   # Guidance
 
   - Do not preamble.
+  - Temporal context (today's date, resolution deadline, time remaining) is provided in the prompt. Do not estimate or compute dates yourself; rely on the supplied values.
   - Assign precise, justified numerical likelihoods (e.g., 42%, 2.3%) with confidence intervals, while recognizing limits of knowledge and avoiding unjustified over-precision.
   - Put extra weight on status quo outcomes since the world usually changes slowly.
   - For each adjustment — to the base rate, for cognitive/source biases, or to confidence — explicitly state the direction, magnitude, supporting evidence, and reasoning.
@@ -40,7 +41,7 @@ SUPERFORECASTER_SYSTEM_PROMPT = ERB.new(<<~SUPERFORECASTER_SYSTEM_PROMPT, trim_m
 SUPERFORECASTER_SYSTEM_PROMPT
 
 FORECAST_PROMPT_TEMPLATE = ERB.new(File.read('./lib/prompt_templates/forecast.erb'), trim_mode: '-')
-SITUATION_SNAPSHOT = File.read('./lib/prompt_templates/_situation_snapshot.erb')
+SITUATION_SNAPSHOT = ERB.new(File.read('./lib/prompt_templates/_situation_snapshot.erb'), trim_mode: '-')
 
 RESEARCH_PROMPT_TEMPLATE = ERB.new(File.read('./lib/prompt_templates/research.erb'), trim_mode: '-')
 

--- a/test/run_tests.rb
+++ b/test/run_tests.rb
@@ -4,3 +4,4 @@
 require_relative 'test_helper'
 require_relative 'test_aggregation'
 require_relative 'test_continuous_cdf'
+require_relative 'test_metaculus'

--- a/test/test_metaculus.rb
+++ b/test/test_metaculus.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class TestMetaculus < Minitest::Test
+  # ─── resolve_time ───────────────────────────────────────────────────────────
+
+  def test_resolve_time_from_scheduled
+    q = build_question('scheduled_resolve_time' => '2027-12-31T00:00:00Z')
+    assert_equal Time.parse('2027-12-31T00:00:00Z'), q.resolve_time
+  end
+
+  def test_resolve_time_falls_back_to_actual
+    q = build_question('actual_resolve_time' => '2025-01-15T00:00:00Z')
+    assert_equal Time.parse('2025-01-15T00:00:00Z'), q.resolve_time
+  end
+
+  def test_resolve_time_prefers_scheduled_over_actual
+    q = build_question(
+      'scheduled_resolve_time' => '2027-12-31T00:00:00Z',
+      'actual_resolve_time' => '2025-01-15T00:00:00Z'
+    )
+    assert_equal Time.parse('2027-12-31T00:00:00Z'), q.resolve_time
+  end
+
+  def test_resolve_time_returns_nil_when_no_dates
+    q = build_question({})
+    assert_nil q.resolve_time
+  end
+
+  # ─── placeholder_resolve? ───────────────────────────────────────────────────
+
+  def test_placeholder_resolve_when_year_2099
+    q = build_question('scheduled_resolve_time' => '2099-01-01T00:00:00Z')
+    assert q.placeholder_resolve?
+  end
+
+  def test_placeholder_resolve_when_year_2100
+    q = build_question('scheduled_resolve_time' => '2100-01-02T00:00:00Z')
+    assert q.placeholder_resolve?
+  end
+
+  def test_placeholder_resolve_false_for_normal_date
+    q = build_question('scheduled_resolve_time' => '2027-12-31T00:00:00Z')
+    refute q.placeholder_resolve?
+  end
+
+  def test_placeholder_resolve_false_when_no_resolve_time
+    q = build_question({})
+    refute q.placeholder_resolve?
+  end
+
+  # ─── time_until_resolve ─────────────────────────────────────────────────────
+
+  def test_time_until_resolve_future
+    future = (Time.now + (86_400 * 30) + 60) # 30 days + 60s buffer
+    q = build_question('scheduled_resolve_time' => future.utc.iso8601)
+    assert_match(/\d+ days/, q.time_until_resolve)
+    days = q.time_until_resolve.match(/(\d+) days/)[1].to_i
+    assert days >= 29, "expected at least 29 days, got #{days}"
+  end
+
+  def test_time_until_resolve_includes_years
+    future = (Time.now + (86_400 * 500) + 60) # ~1.37 years + buffer
+    q = build_question('scheduled_resolve_time' => future.utc.iso8601)
+    assert_match(/\d+ days.*≈.*year/, q.time_until_resolve)
+  end
+
+  def test_time_until_resolve_one_day_singular
+    future = (Time.now + 86_400 + 60) # 1 day + buffer
+    q = build_question('scheduled_resolve_time' => future.utc.iso8601)
+    assert_match(/1 day\b/, q.time_until_resolve)
+  end
+
+  def test_time_until_resolve_already_resolved
+    past = Time.now - 86_400
+    q = build_question('scheduled_resolve_time' => past.utc.iso8601)
+    assert_equal 'Already resolved', q.time_until_resolve
+  end
+
+  def test_time_until_resolve_placeholder
+    q = build_question('scheduled_resolve_time' => '2100-01-02T00:00:00Z')
+    assert_equal 'No fixed resolution date', q.time_until_resolve
+  end
+
+  def test_time_until_resolve_nil_when_no_date
+    q = build_question({})
+    assert_nil q.time_until_resolve
+  end
+
+  # ─── close_time ─────────────────────────────────────────────────────────────
+
+  def test_close_time_from_scheduled
+    q = build_question('scheduled_close_time' => '2027-12-30T00:00:00Z')
+    assert_equal Time.parse('2027-12-30T00:00:00Z'), q.close_time
+  end
+
+  def test_close_time_falls_back_to_actual
+    q = build_question('actual_close_time' => '2025-01-14T00:00:00Z')
+    assert_equal Time.parse('2025-01-14T00:00:00Z'), q.close_time
+  end
+
+  def test_close_time_returns_nil_when_no_dates
+    q = build_question({})
+    assert_nil q.close_time
+  end
+
+  # ─── time_until_close ───────────────────────────────────────────────────────
+
+  def test_time_until_close_future
+    future = (Time.now + (86_400 * 14) + 60) # 14 days + buffer
+    q = build_question('scheduled_close_time' => future.utc.iso8601)
+    assert_match(/\d+ days/, q.time_until_close)
+    days = q.time_until_close.match(/(\d+) days/)[1].to_i
+    assert days >= 13, "expected at least 13 days, got #{days}"
+  end
+
+  def test_time_until_close_already_closed
+    past = Time.now - 86_400
+    q = build_question('scheduled_close_time' => past.utc.iso8601)
+    assert_equal 'Already closed', q.time_until_close
+  end
+
+  def test_time_until_close_nil_when_no_date
+    q = build_question({})
+    assert_nil q.time_until_close
+  end
+
+  # ─── metadata_content ───────────────────────────────────────────────────────
+
+  def test_metadata_includes_resolution_info
+    future = (Time.now + (86_400 * 60) + 60)
+    q = build_question(
+      'scheduled_resolve_time' => future.utc.iso8601,
+      'scheduled_close_time' => (future - 86_400).utc.iso8601,
+      'created_at' => '2025-01-01T00:00:00Z',
+      'scaling' => { 'range_min' => 0, 'range_max' => 100 }
+    )
+    metadata = q.metadata_content
+    assert_match(/Asked On:/, metadata)
+    assert_match(/Scheduled Resolution:.*\(\d+ days\)/, metadata)
+    assert_match(/Forecasting Closes:.*\(\d+ days\)/, metadata)
+  end
+
+  def test_metadata_placeholder_resolution
+    q = build_question(
+      'scheduled_resolve_time' => '2100-01-02T00:00:00Z',
+      'scheduled_close_time' => '2100-01-01T00:00:00Z',
+      'created_at' => '2025-01-01T00:00:00Z',
+      'scaling' => { 'range_min' => 0, 'range_max' => 100 }
+    )
+    metadata = q.metadata_content
+    assert_match(/No fixed resolution date/, metadata)
+  end
+
+  def test_metadata_already_resolved
+    past = Time.now - 86_400
+    q = build_question(
+      'scheduled_resolve_time' => past.utc.iso8601,
+      'scheduled_close_time' => (past - 86_400).utc.iso8601,
+      'created_at' => '2025-01-01T00:00:00Z',
+      'scaling' => { 'range_min' => 0, 'range_max' => 100 }
+    )
+    metadata = q.metadata_content
+    assert_match(/Already resolved/, metadata)
+    assert_match(/Already closed/, metadata)
+  end
+
+  def test_metadata_without_resolution_dates
+    q = build_question(
+      'created_at' => '2025-01-01T00:00:00Z',
+      'scaling' => { 'range_min' => 0, 'range_max' => 100 }
+    )
+    metadata = q.metadata_content
+    assert_match(/Asked On:/, metadata)
+    refute_match(/Scheduled Resolution/, metadata)
+    refute_match(/Forecasting Closes/, metadata)
+  end
+
+  # ─── leap-year boundary ─────────────────────────────────────────────────────
+
+  def test_time_until_resolve_across_leap_year
+    future = (Time.now + (86_400 * 600) + 60) # ~1.64 years + buffer
+    q = build_question('scheduled_resolve_time' => future.utc.iso8601)
+    refute_nil q.time_until_resolve
+    refute_equal 'No fixed resolution date', q.time_until_resolve
+    refute_equal 'Already resolved', q.time_until_resolve
+  end
+
+  # ─── zero / negative remaining time ─────────────────────────────────────────
+
+  def test_time_until_resolve_just_now
+    # Time exactly now resolves as "Already resolved" due to <= check
+    now = Time.now
+    q = build_question('scheduled_resolve_time' => now.utc.iso8601)
+    assert_equal 'Already resolved', q.time_until_resolve
+  end
+
+  private
+
+  def build_question(question_overrides = {})
+    data = {
+      'question' => question_overrides
+    }
+    data['created_at'] ||= '2025-01-01T00:00:00Z'
+    Metaculus::Question.new(data: data)
+  end
+end


### PR DESCRIPTION
## Summary

Pre-computes temporal information (resolution date, close date, days remaining) at prompt-build time so the LLM doesn't need to do date arithmetic — which it's notoriously bad at.

## Changes

### `lib/metaculus.rb`
- **5 new `Question` methods**: `resolve_time`, `close_time`, `placeholder_resolve?`, `time_until_resolve`, `time_until_close`
- **Updated `metadata_content`**: Now includes `Scheduled Resolution:` (with days remaining) and `Forecasting Closes:` lines
- Fixed pre-existing nil-safety bug on `units.empty?`

### `lib/prompt_templates/_situation_snapshot.erb`
- Replaces vague "time remaining before outcome becomes known" with computed `question.time_until_resolve`

### `lib/prompts.rb`
- `SITUATION_SNAPSHOT` changed from raw string to ERB template
- Added temporal-context defensive note to `SUPERFORECASTER_SYSTEM_PROMPT`

### `lib/prompt_templates/shared_forecast.erb`
- Renders `SITUATION_SNAPSHOT` via `.result(binding)`

### Tests
- 26 new unit tests covering: real/placeholder dates, already-resolved, leap-year boundaries, zero remaining time, singular/plural formatting

## Acceptance criteria

- [x] `Question#resolve_time`, `#close_time`, `#placeholder_resolve?`, `#time_until_resolve` implemented and unit-tested
- [x] `Question#metadata_content` includes resolution date, closing date, and pre-computed time remaining
- [x] `_situation_snapshot.erb` replaces vague instruction with computed value
- [x] `SUPERFORECASTER_SYSTEM_PROMPT` warns models not to compute dates
- [x] Placeholder resolution dates (year ≥ 2099) rendered as "No fixed resolution date"
- [x] Already-resolved questions handled gracefully
- [x] Full test suite passes (55 runs, 497 assertions, 0 failures)