### PR TITLE
Remove the Think Tool (closes #121)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ news.rb → tools_research.rb → forecast.rb (×4 forecasters) → revise_forec
 - **`lib/metaculus.rb`** - Metaculus API client. `Question` class wraps question data; handles all 4 question types (binary, numeric, discrete, multiple_choice).
 - **`lib/prompts.rb`** - System prompts and ERB templates. `SUPERFORECASTER_SYSTEM_PROMPT` encodes the Bayesian methodology (base rates, explicit adjustments, uncertainty calibration).
 - **`lib/response.rb`** - Parses LLM responses across providers. Extracts XML-tagged forecast values (`<probability>`, `<percentiles>`, `<probabilities>`).
-- **`lib/tools.rb`** - Two tools: `SEARCH_TOOL` (calls Perplexity sonar-pro) and `THINK_TOOL` (structured reasoning).
+- **`lib/tools.rb`** - Defines `SEARCH_TOOL` (calls Perplexity sonar-pro for web search) and `Tools.dispatch` (centralized tool-call router used by OpenRouter, DeepSeek, and Perplexity).
 - **`lib/utility.rb`** - File-based caching in `tmp/{post_id}/`. All prompts and outputs are cached for auditability.
 
 ### Question Types & Output Formats

--- a/lib/tools.rb
+++ b/lib/tools.rb
@@ -31,31 +31,6 @@ SEARCH_TOOL = {
   }
 }.freeze
 
-THINK_TOOL = {
-  type: 'function',
-  function: {
-    name: 'think',
-    description: <<~DESCRIPTION,
-      Think out loud, take notes, form plans.
-
-      # Usage
-      - Has no external effects.
-
-      # Relevance
-      - Skip for trivial single-step tasks.
-    DESCRIPTION
-    parameters: {
-      type: 'object',
-      properties: {
-        thoughts: {
-          type: 'string',
-          description: 'The thoughts, notes, or plans.'
-        }
-      }
-    }
-  }
-}.freeze
-
 module Tools
   class << self
     def search(arguments)
@@ -76,12 +51,6 @@ module Tools
       )
     end
 
-    def think(arguments)
-      thoughts = arguments['thoughts']
-      Formatador.display_line "\n[bold][green]Thinking[faint](#{thoughts})[/]"
-      'Thought thoughts.'
-    end
-
     # Shared tool-call dispatch.  Used by all tool-capable clients
     # (OpenRouter, DeepSeek, Perplexity) so that tool routing stays in
     # one place — especially important as #120 adds `submit_forecast`.
@@ -91,8 +60,6 @@ module Tools
       case tool
       when 'search'
         search(arguments).content
-      when 'think'
-        think(arguments)
       else
         raise "Unknown Tool Requested: `#{tool}`"
       end

--- a/tools_research.rb
+++ b/tools_research.rb
@@ -20,7 +20,6 @@ cache(post_id, 'research.json') do
     system: RESEARCHER_SYSTEM_PROMPT,
     tools: [SEARCH_TOOL]
   )
-  @think = false
   @forecast_prompt = FORECAST_PROMPT_TEMPLATE.result(binding)
   @research_prompt = RESEARCH_PROMPT_TEMPLATE.result(binding)
   cache_write(post_id, 'inputs/research.md', @research_prompt)


### PR DESCRIPTION
## Summary

Removes the `THINK_TOOL` function-calling tool and all supporting code — it was dead code that was never passed to any LLM instance.

## Changes

| File | Change |
|------|--------|
| `lib/tools.rb` | Removed `THINK_TOOL` constant (19 lines), `Tools.think` method (5 lines), and `when 'think'` dispatch branch (2 lines) |
| `tools_research.rb` | Removed `@think = false` dead variable |
| `CLAUDE.md` | Updated docs from "Two tools: `SEARCH_TOOL` and `THINK_TOOL`" → "Defines `SEARCH_TOOL` and `Tools.dispatch`" |

## Verification

- `grep -rn "THINK_TOOL\|Tools\.think\|when 'think'" --include="*.rb"` → no results
- `grep -rn "@think" --include="*.rb"` → no results
- `ruby test/run_tests.rb` → 55 runs, 497 assertions, 0 failures, 0 errors

## What's NOT changed

The `<think>` XML tag handling in response parsing and prompt templates is completely separate and preserved — this PR only removes the unused function-calling tool.