### PR TITLE
Add calculator tool to eliminate LLM arithmetic errors (closes #123)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ news.rb → tools_research.rb → forecast.rb (×4 forecasters) → revise_forec
 - **`lib/metaculus.rb`** - Metaculus API client. `Question` class wraps question data; handles all 4 question types (binary, numeric, discrete, multiple_choice).
 - **`lib/prompts.rb`** - System prompts and ERB templates. `SUPERFORECASTER_SYSTEM_PROMPT` encodes the Bayesian methodology (base rates, explicit adjustments, uncertainty calibration).
 - **`lib/response.rb`** - Parses LLM responses across providers. Extracts XML-tagged forecast values (`<probability>`, `<percentiles>`, `<probabilities>`).
-- **`lib/tools.rb`** - Defines `SEARCH_TOOL` (calls Perplexity sonar-pro for web search) and `Tools.dispatch` (centralized tool-call router used by OpenRouter, DeepSeek, and Perplexity).
+- **`lib/tools.rb`** - Defines `SEARCH_TOOL` (calls Perplexity sonar-pro for web search), `CALCULATOR_TOOL` (safe arithmetic via Dentaku), and `Tools.dispatch` (centralized tool-call router used by OpenRouter, DeepSeek, and Perplexity).
 - **`lib/utility.rb`** - File-based caching in `tmp/{post_id}/`. All prompts and outputs are cached for auditability.
 
 ### Question Types & Output Formats

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 ruby '~> 4.0'
 
+gem 'dentaku'
 gem 'erb'
 gem 'excon'
 gem 'formatador'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    bigdecimal (4.1.2)
+    concurrent-ruby (1.3.6)
+    dentaku (3.5.7)
+      bigdecimal
+      concurrent-ruby
     docile (1.4.1)
     drb (2.2.3)
     erb (6.0.4)
@@ -31,6 +36,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  dentaku
   erb
   excon
   formatador

--- a/consensus.rb
+++ b/consensus.rb
@@ -20,7 +20,7 @@ begin
   provider = :anthropic
   Formatador.display "\n[bold][green]# Superforecaster: Summarizing Consensus(#{post_id})…[/] "
   consensus_json = cache(post_id, 'forecasts/consensus.json') do
-    llm = Provider.new(provider, system: CONSENSUS_SYSTEM_PROMPT, reasoning: { effort: 'high' })
+    llm = Provider.new(provider, system: CONSENSUS_SYSTEM_PROMPT, reasoning: { effort: 'high' }, tools: [CALCULATOR_TOOL])
     consensus_prompt = consensus_prompt_with_type(llm, question, FORECAST_CONSENSUS_PROMPT_TEMPLATE)
     cache_write(post_id, 'inputs/consensus.md', consensus_prompt)
     consensus = llm.eval({ 'role': 'user', 'content': consensus_prompt })

--- a/forecast.rb
+++ b/forecast.rb
@@ -17,7 +17,7 @@ cache_write(post_id, 'inputs/system.superforecaster.md', SUPERFORECASTER_SYSTEM_
 provider = FORECASTERS[forecaster_index]
 Formatador.display "\n[bold][green]# Superforecaster[#{forecaster_index}: #{provider}]: Forecasting(#{post_id})…[/] "
 cache(post_id, "forecasts/forecast.#{forecaster_index}.json") do
-  llm_args = { system: SUPERFORECASTER_SYSTEM_PROMPT, temperature: 0.9 }
+  llm_args = { system: SUPERFORECASTER_SYSTEM_PROMPT, temperature: 0.9, tools: [CALCULATOR_TOOL] }
   llm = Provider.new(provider, **llm_args)
   forecast_prompt = prompt_with_type(llm, question, SHARED_FORECAST_PROMPT_TEMPLATE)
   cache_write(post_id, "inputs/forecast.#{forecaster_index}.md", forecast_prompt)

--- a/lib/calculator.rb
+++ b/lib/calculator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'dentaku'
+
+module Calculator
+  class << self
+    def evaluate(expression)
+      calculator = Dentaku::Calculator.new
+      calculator.store(pi: Math::PI)
+      calculator.store(e: Math::E)
+      result = calculator.evaluate(expression)
+      raise "Could not evaluate: #{expression}" if result.nil?
+
+      result.is_a?(BigDecimal) ? result.to_f : result
+    rescue Dentaku::ParseError => e
+      "Parse error: #{e.message}"
+    rescue StandardError => e
+      "Evaluation error: #{e.message}"
+    end
+  end
+end

--- a/lib/tools.rb
+++ b/lib/tools.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'calculator'
+
 SEARCH_TOOL = {
   type: 'function',
   function: {
@@ -31,6 +33,46 @@ SEARCH_TOOL = {
   }
 }.freeze
 
+CALCULATOR_TOOL = {
+  type: 'function',
+  function: {
+    name: 'calculate',
+    description: <<~DESCRIPTION,
+      Evaluate an arithmetic expression safely and return the result.
+
+      # Usage
+      - Use for any computation with more than two numbers or more than one operation.
+      - Use for percentage math, compounding, expected values, Bayes updates.
+      - Use when precision matters (e.g. normalization, log-odds conversion).
+      - Prefer a single expression; chain via multiple calls if needed.
+
+      # Supported
+      - Operators: +, -, *, /, ^ (exponentiation), % (modulo)
+      - Functions: SQRT, LOG, LOG10, LOG2, EXP, ABS, ROUND(n), ROUNDDOWN, ROUNDUP
+      - Constants: PI, E
+      - Grouping: parentheses
+      - Functions are case-insensitive (round, ROUND, Round all work).
+
+      # Examples
+      - "0.35 * 0.8 + 0.65 * 0.2"
+      - "LOG(0.5 / 0.5)"
+      - "100 * (1.02 ^ 5)"
+      - "SQRT(0.3 * 0.7 / 100)"
+      - "ROUND(42.6789, 2)"
+    DESCRIPTION
+    parameters: {
+      type: 'object',
+      properties: {
+        expression: {
+          type: 'string',
+          description: 'The arithmetic expression to evaluate (e.g. "0.35 * 0.8 + 0.65 * 0.2").'
+        }
+      },
+      required: ['expression']
+    }
+  }
+}.freeze
+
 module Tools
   class << self
     def search(arguments)
@@ -51,6 +93,12 @@ module Tools
       )
     end
 
+    def calculate(arguments)
+      expression = arguments['expression']
+      result = Calculator.evaluate(expression)
+      result.to_s
+    end
+
     # Shared tool-call dispatch.  Used by all tool-capable clients
     # (OpenRouter, DeepSeek, Perplexity) so that tool routing stays in
     # one place — especially important as #120 adds `submit_forecast`.
@@ -60,6 +108,8 @@ module Tools
       case tool
       when 'search'
         search(arguments).content
+      when 'calculate'
+        calculate(arguments)
       else
         raise "Unknown Tool Requested: `#{tool}`"
       end

--- a/test/test_calculator.rb
+++ b/test/test_calculator.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/calculator'
+
+class TestCalculator < Minitest::Test
+  # ── basic ops ────────────────────────────────────────────────────────────
+  def test_basic_addition
+    assert_equal 5, Calculator.evaluate('2 + 3')
+  end
+
+  def test_basic_subtraction
+    assert_equal 1, Calculator.evaluate('4 - 3')
+  end
+
+  def test_basic_multiplication
+    assert_equal 12, Calculator.evaluate('3 * 4')
+  end
+
+  def test_basic_division
+    assert_equal 2.5, Calculator.evaluate('5 / 2')
+  end
+
+  def test_exponentiation
+    assert_equal 8, Calculator.evaluate('2 ^ 3')
+  end
+
+  def test_modulo
+    assert_equal 1, Calculator.evaluate('10 % 3')
+  end
+
+  # ── precedence and grouping ──────────────────────────────────────────────
+  def test_operator_precedence
+    assert_equal 14, Calculator.evaluate('2 + 3 * 4')
+  end
+
+  def test_parentheses
+    assert_equal 20, Calculator.evaluate('(2 + 3) * 4')
+  end
+
+  def test_nested_parentheses
+    assert_equal 25, Calculator.evaluate('((2 + 3) * (3 + 2))')
+  end
+
+  # ── math functions ───────────────────────────────────────────────────────
+  def test_sqrt
+    assert_equal 4, Calculator.evaluate('SQRT(16)')
+  end
+
+  def test_log_natural
+    assert_in_delta 1.0, Calculator.evaluate('LOG(E)'), 0.001
+  end
+
+  def test_log10
+    assert_equal 2, Calculator.evaluate('LOG10(100)')
+  end
+
+  def test_log2
+    assert_equal 3, Calculator.evaluate('LOG2(8)')
+  end
+
+  def test_exp
+    assert_in_delta 7.389, Calculator.evaluate('EXP(2)'), 0.001
+  end
+
+  def test_abs_positive
+    assert_equal 5, Calculator.evaluate('ABS(5)')
+  end
+
+  def test_abs_negative
+    assert_equal 5, Calculator.evaluate('ABS(-5)')
+  end
+
+  def test_round_default
+    assert_equal 43, Calculator.evaluate('ROUND(42.6789)')
+  end
+
+  def test_round_with_precision
+    assert_equal 42.68, Calculator.evaluate('ROUND(42.6789, 2)')
+  end
+
+  def test_rounddown
+    assert_equal 42, Calculator.evaluate('ROUNDDOWN(42.6789)')
+  end
+
+  def test_roundup
+    assert_equal 43, Calculator.evaluate('ROUNDUP(42.6789)')
+  end
+
+  # ── case-insensitive functions ───────────────────────────────────────────
+  def test_lowercase_function
+    assert_equal 4, Calculator.evaluate('sqrt(16)')
+  end
+
+  def test_mixed_case_function
+    assert_equal 4, Calculator.evaluate('Sqrt(16)')
+  end
+
+  # ── constants ────────────────────────────────────────────────────────────
+  def test_pi
+    assert_in_delta 3.14159, Calculator.evaluate('PI'), 0.0001
+  end
+
+  def test_e
+    assert_in_delta 2.71828, Calculator.evaluate('E'), 0.0001
+  end
+
+  # ── example expressions from issue #123 ──────────────────────────────────
+  def test_expected_value
+    assert_equal 0.41, Calculator.evaluate('0.35 * 0.8 + 0.65 * 0.2')
+  end
+
+  def test_log_odds
+    assert_equal 0.0, Calculator.evaluate('LOG(0.5 / 0.5)')
+  end
+
+  def test_compound_growth
+    assert_in_delta 110.41, Calculator.evaluate('100 * (1.02 ^ 5)'), 0.01
+  end
+
+  def test_standard_error
+    assert_in_delta 0.0458, Calculator.evaluate('SQRT(0.3 * 0.7 / 100)'), 0.0001
+  end
+
+  def test_round_financial
+    assert_equal 42.68, Calculator.evaluate('ROUND(42.6789, 2)')
+  end
+
+  # ── edge cases ───────────────────────────────────────────────────────────
+  def test_division_by_zero_returns_error_string
+    result = Calculator.evaluate('1 / 0')
+    assert_match(/error/i, result.to_s)
+  end
+
+  def test_malformed_expression_returns_error_string
+    result = Calculator.evaluate('2 + + 3')
+    assert_match(/error/i, result.to_s)
+  end
+
+  def test_empty_string_returns_error_string
+    result = Calculator.evaluate('')
+    assert_match(/error/i, result.to_s)
+  end
+
+  def test_nil_input_returns_error_string
+    result = Calculator.evaluate(nil)
+    assert_match(/error/i, result.to_s)
+  end
+
+  def test_float_precision
+    assert_in_delta 0.3333, Calculator.evaluate('1 / 3'), 0.0001
+  end
+
+  def test_negative_numbers
+    assert_equal(-5, Calculator.evaluate('-2 - 3'))
+  end
+end

--- a/tools_research.rb
+++ b/tools_research.rb
@@ -18,7 +18,7 @@ cache(post_id, 'research.json') do
     model: 'anthropic/claude-opus-4.8',
     reasoning: { effort: 'high' },
     system: RESEARCHER_SYSTEM_PROMPT,
-    tools: [SEARCH_TOOL]
+    tools: [SEARCH_TOOL, CALCULATOR_TOOL]
   )
   @forecast_prompt = FORECAST_PROMPT_TEMPLATE.result(binding)
   @research_prompt = RESEARCH_PROMPT_TEMPLATE.result(binding)


### PR DESCRIPTION
## What

Adds a `calculate` tool available to all LLM providers, backed by the [Dentaku](https://github.com/rubysolo/dentaku) gem for safe arithmetic evaluation. LLMs frequently make arithmetic errors when chaining operations — this tool eliminates that entire class of error.

## Changes

| File | Change |
|---|---|
| `Gemfile` | Add `gem 'dentaku'` |
| `Gemfile.lock` | Updated via `bundle install` |
| `lib/calculator.rb` | **New** — `Calculator.evaluate` using Dentaku with PI/E constants, BigDecimal→Float conversion, and error-safe rescues |
| `lib/tools.rb` | Add `CALCULATOR_TOOL` constant + `Tools.calculate` + `when 'calculate'` dispatch branch |
| `tools_research.rb` | Researcher tools: `[SEARCH_TOOL]` → `[SEARCH_TOOL, CALCULATOR_TOOL]` |
| `consensus.rb` | Add `tools: [CALCULATOR_TOOL]` to consensus LLM |
| `forecast.rb` | Add `tools: [CALCULATOR_TOOL]` to forecaster LLM args |
| `test/test_calculator.rb` | **New** — 35 tests: basic ops, precedence, math functions, case-insensitivity, constants, edge cases |
| `AGENTS.md` | Update tools documentation |

## Dentaku API notes

The original spec (issue #123) assumed certain operators — Dentaku's actual API differs:

| Expected | Dentaku reality |
|---|---|
| `**` | `^` (caret) |
| `floor()` / `ceil()` | `ROUNDDOWN()` / `ROUNDUP()` |
| `pi`, `e` built-in | Must store manually: `calculator.store(pi:, e:)` |
| `ROUND()` → Float | Returns `BigDecimal` → convert `.to_f` |

All dispatch goes through `Tools.dispatch` — a single `when 'calculate'` branch covers all three clients (OpenRouter, DeepSeek, Perplexity). No per-client edits needed.

## Verification

- **35 calculator tests**: 0 failures, 0 errors
- **Full test suite**: 55 runs, 497 assertions, 0 failures
- **All modified files**: Syntax OK
- **Require chain**: `CALCULATOR_TOOL` loads correctly through `script_helpers.rb`