### PR TITLE
fix: drop tools for Perplexity forecaster, fix SEARCH_TOOL required placement

### DIFF
--- a/forecast.rb
+++ b/forecast.rb
@@ -17,7 +17,10 @@ cache_write(post_id, 'inputs/system.superforecaster.md', SUPERFORECASTER_SYSTEM_
 provider = FORECASTERS[forecaster_index]
 Formatador.display "\n[bold][green]# Superforecaster[#{forecaster_index}: #{provider}]: Forecasting(#{post_id})…[/] "
 cache(post_id, "forecasts/forecast.#{forecaster_index}.json") do
-  llm_args = { system: SUPERFORECASTER_SYSTEM_PROMPT, temperature: 0.9, tools: [CALCULATOR_TOOL] }
+  # Perplexity Chat Completions doesn't support function calling (requires Agent API).
+  # Use CALCULATOR_TOOL for providers that support it (OpenRouter/Anthropic, OpenAI, DeepSeek).
+  tools = provider == :perplexity ? [] : [CALCULATOR_TOOL]
+  llm_args = { system: SUPERFORECASTER_SYSTEM_PROMPT, temperature: 0.9, tools: tools }
   llm = Provider.new(provider, **llm_args)
   forecast_prompt = prompt_with_type(llm, question, SHARED_FORECAST_PROMPT_TEMPLATE)
   cache_write(post_id, "inputs/forecast.#{forecaster_index}.md", forecast_prompt)

--- a/lib/tools.rb
+++ b/lib/tools.rb
@@ -27,9 +27,9 @@ SEARCH_TOOL = {
           type: 'string',
           description: 'Full sentences or paragraphs to prompt web search with context and instructions.'
         }
-      }
-    },
-    required: ['prompt']
+      },
+      required: ['prompt']
+    }
   }
 }.freeze
 


### PR DESCRIPTION
## Problem
Perplexity Chat Completions endpoint returns `400` when `tools` are included:
```
"Tool parameters must be a JSON object"
```
The Chat Completions endpoint does not support function calling — tools require their Agent API.

## Changes
- **`forecast.rb`**: Skip `CALCULATOR_TOOL` when provider is `:perplexity`. The `Perplexity` class already handles empty tools by falling back to native `web_search_options`. Other providers (Anthropic, OpenAI, DeepSeek) keep the tool.
- **`lib/tools.rb`**: Fix `SEARCH_TOOL` where `required: ["prompt"]` was at the `function` level instead of inside `parameters` (JSON Schema violation). Now consistent with `CALCULATOR_TOOL`.

## Verification
- Direct Perplexity call with `sonar-reasoning-pro` (no tools) works correctly
- Direct Perplexity call with tools (any format) returns 400 on all `sonar*` models
- JSON output of both tool definitions confirmed well-formed