### PR TITLE
fix: pre-render situation snapshot so it doesn't clobber the prompt

### DIFF
--- a/lib/prompt_templates/shared_forecast.erb
+++ b/lib/prompt_templates/shared_forecast.erb
@@ -27,4 +27,4 @@ Before forming your probability estimate, complete each of these five steps expl
 
 - Form your own probability estimate from the research before consulting the community aggregates. State this independent estimate explicitly, then note whether the aggregates cause you to revise it and why.
 - Before your forecast, write:
-<%= SITUATION_SNAPSHOT.result(binding) -%>
+<%= situation_snapshot -%>

--- a/lib/prompts.rb
+++ b/lib/prompts.rb
@@ -116,6 +116,7 @@ FORMAT_REINFORCEMENT
 
 def prompt_with_type(llm, question, prompt_template)
   forecast_context = FORECAST_PROMPT_TEMPLATE.result(binding)
+  situation_snapshot = SITUATION_SNAPSHOT.result(binding)
   prompt = prompt_template.result(binding)
   prompt += case question.type
             when 'binary'


### PR DESCRIPTION
## Problem

Recent changes broke forecast prompts: **the question is no longer fed to the forecasters.** Forecasters were receiving a prompt that began with the situation-snapshot bullets and contained none of the question context, research, or decomposition instructions.

## Root cause

Commit `2eb53ea` (#126, "Pre-compute time-remaining in templates") turned `_situation_snapshot.erb` from a static string into a real ERB template, rendered **nested inside** `shared_forecast.erb` with a shared binding:

```erb
<%= SITUATION_SNAPSHOT.result(binding) -%>
```

ERB compiles each template to code that accumulates output in a local `_erbout`. The `binding` here captured the outer template's *live* `_erbout` buffer mid-render. The inner template's compiled code starts with `_erbout = +''`, which **reset that shared buffer to empty** — discarding everything rendered before it (question context, research, the five-step decomposition). Only the snapshot text, emitted after the reset, survived.

## Fix

Pre-render the snapshot to a string **before** the outer template runs — the exact pattern `forecast_context` already uses safely — then reference it as a plain local:

```ruby
forecast_context   = FORECAST_PROMPT_TEMPLATE.result(binding)
situation_snapshot = SITUATION_SNAPSHOT.result(binding)
prompt             = prompt_template.result(binding)
```

```erb
<%= situation_snapshot -%>
```

Because the result is captured into a variable before the main render begins, the inner template's buffer reset no longer clobbers anything. The pre-computed time-remaining feature still works.

## Verification

- Rendered the prompt with a question double: it again contains the question title, research, decomposition instructions, **and** the time-remaining line, in order.
- Full suite passes: `55 runs, 497 assertions, 0 failures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)