### PR TITLE
fix: strip whitespace and skip blank lines when parsing probabilities/percentiles

### DIFF
--- a/lib/helpers/response.rb
+++ b/lib/helpers/response.rb
@@ -11,6 +11,8 @@ module ResponseHelpers
     @percentiles ||= begin
       percentiles = {}
       extracted_content('percentiles').split("\n").each do |line|
+        line = line.strip
+        next if line.empty?
         key, value = line.split(': ', 2)
         key = key.split('Percentile ', 2).last
         value = value.split(' ', 2).first
@@ -43,8 +45,10 @@ module ResponseHelpers
     @probabilities ||= begin
       probabilities = {}
       extracted_content('probabilities').split("\n").each do |line|
+        line = line.strip
+        next if line.empty?
         key, value = line.split(': ', 2)
-        probabilities[key] = parse_probability(value)
+        probabilities[key.strip] = parse_probability(value)
       end
       probabilities
     end


### PR DESCRIPTION
Multiple choice submissions failed when the LLM indented option lines inside `<probabilities>`, since leading spaces on the key caused Metaculus to reject the option name. Same defensive treatment applied to the percentiles parser.

## Changes
- Strip each line before parsing in both `probabilities` and `percentiles` methods
- Skip blank lines to avoid empty-key parsing errors
- Belt-and-suspenders: also strip the key after splitting in `probabilities`

## Context
The prompt template at `lib/prompts.rb:85` joins multiple choice options with `"\n  "` (two spaces of indentation on subsequent lines). When the LLM follows this formatting, keys like `"  US"` don't match the Metaculus API's expected option names.