### PR TITLE
Extend tournament_retro.rb with resolution, prediction, and comment context

### DIFF
--- a/lib/metaculus.rb
+++ b/lib/metaculus.rb
@@ -51,6 +51,24 @@ class Metaculus
     exit(1)
   end
 
+  def self.get_comments(post_id)
+    new.get_comments(post_id)
+  end
+
+  def get_comments(post_id)
+    excon_response = connection.get(
+      path: '/api2/comments/',
+      query: {
+        question: post_id,
+        author: ENV['METACULUS_BOT_ID']
+      }
+    )
+    JSON.parse(excon_response.body)
+  rescue Excon::Error => e
+    puts e.response.inspect
+    []
+  end
+
   def self.list_resolved_tournament_questions(tournament_id)
     new.list_resolved_tournament_questions(tournament_id)
   end
@@ -410,6 +428,135 @@ class Metaculus
 
     def spot_peer_score
       @spot_peer_score ||= question.dig('my_forecasts', 'score_data', 'spot_peer_score')
+    end
+
+    def resolution
+      raw = question['resolution']
+      return 'Unresolved' if raw.nil?
+
+      case type
+      when 'binary'
+        case raw
+        when 0.0, 0 then 'No'
+        when 1.0, 1 then 'Yes'
+        when -1 then 'Ambiguous'
+        else raw.to_s
+        end
+      when 'numeric'
+        raw.to_s
+      when 'discrete'
+        label = options[raw]
+        label ? "#{raw} (#{label})" : raw.to_s
+      when 'multiple_choice'
+        options[raw] || raw.to_s
+      else
+        raw.to_s
+      end
+    end
+
+    def my_prediction
+      latest = question.dig('my_forecasts', 'latest')
+      return 'No forecast' unless latest
+
+      values = latest['forecast_values']
+      return 'No forecast values' unless values
+
+      case type
+      when 'binary'
+        p_yes = (values[1] * 100).round(1)
+        "#{p_yes}% Yes"
+      when 'numeric', 'discrete'
+        cdf = values
+        x_axis = scaling['continuous_range']
+        if x_axis && !x_axis.empty?
+          idx = cdf.index { |v| v >= 0.5 } || (cdf.length - 1)
+          x_val = x_axis[idx]
+          range = upper_bound - lower_bound
+          x_span = x_axis.last - x_axis.first
+          actual = if x_span.positive?
+                     (lower_bound + x_val * range / x_span).round(2)
+                   else
+                     x_val.round(2)
+                   end
+          unit_str = units.empty? ? '' : " #{units}"
+          "#{actual}#{unit_str} (P50)"
+        else
+          # fallback: show first few CDF values
+          "CDF array (#{cdf.length} points)"
+        end
+      when 'multiple_choice'
+        options.zip(values).map do |opt, prob|
+          "#{opt}: #{(prob * 100).round(1)}%"
+        end.join(', ')
+      else
+        values.inspect
+      end
+    end
+
+    def error_summary
+      res = question['resolution']
+      return 'Not yet resolved' if res.nil?
+
+      latest = question.dig('my_forecasts', 'latest')
+      return 'No forecast to compare' unless latest
+
+      values = latest['forecast_values']
+      return 'No forecast values' unless values
+
+      case type
+      when 'binary'
+        if res == -1
+          return 'Ambiguous resolution'
+        end
+
+        p_yes = values[1]
+        diff = (res - p_yes).abs
+        direction = if p_yes > res
+                      'overconfident in Yes'
+                    elsif p_yes < res
+                      'underconfident in Yes'
+                    else
+                      'perfect'
+                    end
+        format('Error: %<diff>.1f%% (%<direction>s)', diff: diff * 100, direction: direction)
+      when 'numeric', 'discrete'
+        cdf = values
+        x_axis = scaling['continuous_range']
+        if x_axis && !x_axis.empty?
+          idx = cdf.index { |v| v >= 0.5 } || (cdf.length - 1)
+          p50_x = x_axis[idx]
+          range = upper_bound - lower_bound
+          x_span = x_axis.last - x_axis.first
+          p50 = if x_span.positive?
+                  lower_bound + p50_x * range / x_span
+                else
+                  p50_x
+                end
+          abs_error = (res.to_f - p50).abs.round(2)
+          unit_str = units.empty? ? '' : " #{units}"
+          "Absolute error: #{abs_error}#{unit_str} (resolved #{res}, predicted P50 #{p50.round(2)})"
+        else
+          'Cannot compute error (no scaling range)'
+        end
+      when 'multiple_choice'
+        correct_idx = res.to_i
+        prob_assigned = values[correct_idx] || 0
+        surprisal = ((1 - prob_assigned) * 100).round(1)
+        correct_option = options[correct_idx] || "option #{correct_idx}"
+        "Surprisal: #{surprisal}% (assigned #{(prob_assigned * 100).round(1)}% to correct answer '#{correct_option}')"
+      else
+        'Unknown question type'
+      end
+    end
+
+    def my_comment
+      comments = Metaculus.get_comments(post_id)
+      return 'No comments found' if comments.nil? || comments.empty?
+
+      latest = comments.is_a?(Array) ? comments.first : comments['results']&.first
+      return 'No comment text' unless latest
+
+      latest['text'] || latest[:text] || 'No comment text available'
     end
 
     def submit(response)

--- a/tournament_retro.rb
+++ b/tournament_retro.rb
@@ -16,8 +16,14 @@ questions.reverse!
 questions.each do |q|
   data << <<~QUESTION
     <forecast>
-    <spot_peer_score>#{q.spot_peer_score.round}</spot_peer_score>
-    <title>#{q.title}</title>
+      <id>#{q.post_id}</id>
+      <title>#{q.title}</title>
+      <type>#{q.type}</type>
+      <spot_peer_score>#{q.spot_peer_score.round}</spot_peer_score>
+      <resolution>#{q.resolution}</resolution>
+      <my_prediction>#{q.my_prediction}</my_prediction>
+      <error>#{q.error_summary}</error>
+      <my_comment>#{q.my_comment}</my_comment>
     </forecast>
   QUESTION
 end
@@ -28,16 +34,20 @@ provider = :deepseek
 llm = Provider.new(provider, system: '')
 
 retro_prompt = <<~RETRO_PROMPT
-I am participating in a forecasting tournament. Below are the titles of some of my recent forecasts and my score, where higher is better.
+  I am participating in a forecasting tournament. Below are my recent forecasts with scores, resolutions, predictions, error analyses, and my reasoning comments.
 
   <forecasts>
   #{data.join.strip}
   </forecasts>
 
-  Review this data, then:
+  Review this data thoroughly, then:
     - identify commonalities among the lowest and highest scores
+    - analyze error patterns: direction (over/under confident), magnitude, and question-type trends
+    - evaluate reasoning quality: did my comments reveal flawed assumptions, missing base rates, or confirmation bias?
     - identify distinctions between highest and lowest scores
     - recommend how lower scores could be improved upon (skipping questions is NOT an option)
+    - identify which question types I perform best/worst on and why
+    - recommend specific, actionable improvements to my forecasting process
     - recommend how to improve this prompt to better analyze results and provide recommendations
 RETRO_PROMPT
 


### PR DESCRIPTION
Closes #152

## Changes

### New methods in `lib/metaculus.rb`

- **`Metaculus.get_comments(post_id)`** — Fetch the bot's own comments via `GET /api2/comments/?question=<id>&author=<BOT_ID>`
- **`Question#resolution`** — Human-readable resolution (e.g., `Yes`/`No`/`Ambiguous` for binary, numeric value, bucket label for discrete, option name for multiple choice)
- **`Question#my_prediction`** — Human-readable latest forecast (e.g., `5.0% Yes` for binary, P50 value for numeric/discrete, per-option percentages for multiple choice)
- **`Question#error_summary`** — Pre-computed error magnitude with direction (over/under confident for binary, absolute error for numeric, surprisal for multiple choice)
- **`Question#my_comment`** — Fetch and return the bot's most recent comment text

### Changes to `tournament_retro.rb`

- Extended the XML per-question structure with `<id>`, `<type>`, `<resolution>`, `<my_prediction>`, `<error>`, and `<my_comment>` fields
- Updated the retro prompt to analyze:
  - Error patterns (direction, magnitude, question-type trends)
  - Reasoning quality (flawed assumptions, missing base rates, confirmation bias)
  - Question-type performance patterns
  - Specific actionable improvement recommendations

## Verification

- Syntax check passes on both files
- Tested binary question methods (resolution, prediction, error) with simulated resolved data:
  - `Yes (1.0)`: Resolution=`Yes`, Error=`95.0% (underconfident in Yes)`
  - `No (0.0)`: Resolution=`No`, Error=`5.0% (overconfident in Yes)`
  - `Ambiguous (-1)`: Resolution=`Ambiguous`, Error=`Ambiguous resolution`
  - `nil`: Resolution=`Unresolved`, Error=`Not yet resolved`