### PR TITLE
fix: handle string resolution in error_summary

### DIFF
--- a/lib/metaculus.rb
+++ b/lib/metaculus.rb
@@ -494,7 +494,7 @@ class Metaculus
     end
 
     def error_summary
-      res = question['resolution']
+      res = question['resolution']&.to_f
       return 'Not yet resolved' if res.nil?
 
       latest = question.dig('my_forecasts', 'latest')


### PR DESCRIPTION
The Metaculus API sometimes returns `question['resolution']` as a String instead of a numeric type, causing `NoMethodError: undefined method '-' for String` in `error_summary` when running `tournament_retro.rb`.

**Fix**: Convert `question['resolution']` to Float via safe navigation (`&.to_f`), which:
- Preserves the nil guard for unresolved questions (nil stays nil)
- Handles string resolutions like `"1"` → `1.0`
- Handles ambiguous resolutions like `"-1"` → `-1.0` (still matches `== -1`)
- Is a no-op if the value is already numeric