### PR TITLE
Remove default extremization from consensus aggregation

### DIFF
--- a/lib/aggregation.rb
+++ b/lib/aggregation.rb
@@ -6,7 +6,7 @@
 # averaging the inverse CDF at each quantile.
 module Aggregation
   EPSILON = 1.0e-6
-  DEFAULT_EXTREMIZATION_FACTOR = 1.5
+  DEFAULT_EXTREMIZATION_FACTOR = 1.0
 
   module_function
 

--- a/lib/prompt_templates/forecast_consensus.erb
+++ b/lib/prompt_templates/forecast_consensus.erb
@@ -13,7 +13,7 @@ Your consensus forecast will be based on the context of these forecasts from oth
 <%- if @mechanical_baseline -%>
 # Mechanical aggregate baseline
 
-The forecasts above have been pooled using a calibrated mechanical aggregator (log-odds pool with extremization for binary and multiple-choice; quantile average for numeric/discrete). This baseline is empirically well-calibrated relative to medians or arithmetic means and should serve as your starting point.
+The forecasts above have been pooled using a calibrated mechanical aggregator (log-odds mean for binary and multiple-choice; quantile average for numeric/discrete). This baseline is empirically well-calibrated relative to medians or arithmetic means and should serve as your starting point.
 
 <baseline>
 <%= @mechanical_baseline %>
@@ -28,4 +28,4 @@ Work only from the forecasts provided above. Do not introduce independent analys
 
 - Identify the 2-3 largest divergences between the forecasts and explain which reasoning path is more epistemically sound and why, citing the forecasts directly.
 - If you move the headline number more than ~10 percentage points (binary or per-option multiple choice) or more than ~10% of the inter-quartile range (numeric/discrete) away from the baseline, explicitly state which forecast's reasoning is decisive and why it overrides the pool.
-- After arriving at your consensus estimate, apply an extremization check: if the forecasts consistently point in one direction, explicitly ask whether the consensus should be pushed further from 50%. State whether you are applying an extremization adjustment, by how much, and why. Only adjust if the cross-forecaster evidence genuinely warrants it — do not extremize mechanically.
+

--- a/lib/prompts.rb
+++ b/lib/prompts.rb
@@ -139,9 +139,8 @@ CONSENSUS_SYSTEM_PROMPT = ERB.new(<<~CONSENSUS_SYSTEM_PROMPT, trim_mode: '-').re
 
   - Do not preamble.
   - Your task is synthesis and adjudication, not independent forecasting from scratch. The input forecasts have already done that work — do not re-derive base rates or decompose the problem independently.
-  - Anchor on the mechanical aggregate baseline supplied with the forecasts. It pools the inputs in a calibrated way (log-odds with extremization for binary/multiple-choice; quantile averaging for distributions) and is the right starting point. Departures from the baseline must be justified by reasoning quality, not by raw disagreement.
+  - Anchor on the mechanical aggregate baseline supplied with the forecasts. It pools the inputs in a calibrated way (log-odds mean for binary/multiple-choice; quantile averaging for distributions) and is the right starting point. Departures from the baseline must be justified by reasoning quality, not by raw disagreement.
   - Weight forecasts by both stated confidence and epistemic quality. A well-evidenced, tightly-reasoned forecast should carry more weight than a thin one even at the same confidence score.
-  - LLMs systematically underreact and cluster probabilities near 50%. Maintain awareness of this bias throughout synthesis.
   - Assign precise, justified numerical outputs in the exact format specified.
 CONSENSUS_SYSTEM_PROMPT
 

--- a/lib/utility.rb
+++ b/lib/utility.rb
@@ -89,11 +89,21 @@ def mechanical_baseline(question, forecasts)
   case question.type
   when 'binary'
     pooled = Aggregation.pool_binary(forecasts.map(&:probability))
-    "Log-odds pool (extremization a=#{Aggregation.extremization_factor}): #{(pooled * 100).round(1)}%"
+    a = Aggregation.extremization_factor
+    if a == 1.0
+      "Log-odds mean: #{(pooled * 100).round(1)}%"
+    else
+      "Log-odds pool (extremization a=#{a}): #{(pooled * 100).round(1)}%"
+    end
   when 'multiple_choice'
     pooled = Aggregation.pool_multiple_choice(forecasts.map(&:probabilities))
     lines = pooled.map { |k, v| "  #{k}: #{(v * 100).round(1)}%" }
-    "Softmax-of-log pool (extremization a=#{Aggregation.extremization_factor}):\n#{lines.join("\n")}"
+    a = Aggregation.extremization_factor
+    if a == 1.0
+      "Softmax-of-log mean:\n#{lines.join("\n")}"
+    else
+      "Softmax-of-log pool (extremization a=#{a}):\n#{lines.join("\n")}"
+    end
   when 'numeric', 'discrete'
     keys = forecasts.first.percentiles.keys.sort
     arrays = forecasts.map { |f| keys.map { |k| f.percentiles[k] } }

--- a/test/test_aggregation.rb
+++ b/test/test_aggregation.rb
@@ -134,9 +134,9 @@ class TestAggregation < Minitest::Test
 
   # ─── extremization factor ENV override ──────────────────────────────────────
 
-  def test_extremization_factor_defaults_to_one_point_five
+  def test_extremization_factor_defaults_to_one
     ENV.delete('EXTREMIZATION_FACTOR')
-    assert_in_delta 1.5, Aggregation.extremization_factor, 1e-12
+    assert_in_delta 1.0, Aggregation.extremization_factor, 1e-12
   end
 
   def test_extremization_factor_reads_env


### PR DESCRIPTION
Closes #159.

- Set `DEFAULT_EXTREMIZATION_FACTOR` to `1.0` (was `1.5`), so the default is now a simple log-odds mean / softmax-of-log mean rather than an extremized pool.
- `mechanical_baseline` labels now conditionally show "Log-odds mean" / "Softmax-of-log mean" when `a == 1.0`, and the original "Log-odds pool (extremization a=…)" format when `a != 1.0` (e.g. when overridden via `EXTREMIZATION_FACTOR` env var).
- Removed the "LLMs systematically underreact…" line from `CONSENSUS_SYSTEM_PROMPT`.
- Changed "log-odds with extremization" / "log-odds pool with extremization" → "log-odds mean" across prompt files.
- Removed the extremization check paragraph from `forecast_consensus.erb`.
- Updated the default extremization factor test to expect `1.0`.