### PR TITLE
Improve forecaster system prompt: reference-class baselines, numeric calibration, softer clamping, alternative scenarios

### DIFF
--- a/lib/helpers/response.rb
+++ b/lib/helpers/response.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../aggregation'
+
 module ResponseHelpers
   def extracted_content(*tags)
     extract_xml(content, *tags).last
@@ -57,7 +59,7 @@ module ResponseHelpers
   def probability
     @probability ||= begin
       probability = parse_probability(extracted_content('probability'))
-      clamped = probability.clamp(0.001, 0.999)
+      clamped = probability.clamp(Aggregation::EPSILON, 1.0 - Aggregation::EPSILON)
       warn "WARNING: probability #{probability} clamped to #{clamped}" if clamped != probability
       clamped
     end
@@ -70,6 +72,10 @@ module ResponseHelpers
     value = text.to_f
     value /= 100.0 if text.include?('%') || value > 1.0
     value
+  end
+
+  def calibration_disclaimer
+    @calibration_disclaimer ||= extracted_content('calibration_disclaimer')
   end
 
   def stripped_content(*tags)

--- a/lib/prompt_templates/_situation_snapshot.erb
+++ b/lib/prompt_templates/_situation_snapshot.erb
@@ -1,3 +1,3 @@
 - Time remaining until resolution: <%= question.time_until_resolve || 'see Question Metadata' %>
-- The status quo outcome if nothing changed.
+- The reference-class base rate and the status quo outcome if nothing changed.
 - The expectations of experts and markets.

--- a/lib/prompt_templates/shared_forecast.erb
+++ b/lib/prompt_templates/shared_forecast.erb
@@ -28,3 +28,7 @@ Before forming your probability estimate, complete each of these five steps expl
 - Form your own probability estimate from the research before consulting the community aggregates. State this independent estimate explicitly, then note whether the aggregates cause you to revise it and why.
 - Before your forecast, write:
 <%= situation_snapshot -%>
+
+## Alternative Scenario
+
+Before you finalize your forecast, describe the single most plausible scenario that would produce the opposite outcome. State its estimated probability and what specific evidence or events would need to materialize for this scenario to occur.

--- a/lib/prompts.rb
+++ b/lib/prompts.rb
@@ -30,7 +30,8 @@ SUPERFORECASTER_SYSTEM_PROMPT = ERB.new(<<~SUPERFORECASTER_SYSTEM_PROMPT, trim_m
   - Do not preamble.
   - Temporal context (today's date, resolution deadline, time remaining) is provided in the prompt. Do not estimate or compute dates yourself; rely on the supplied values.
   - Assign precise, justified numerical likelihoods (e.g., 42%, 2.3%) with confidence intervals, while recognizing limits of knowledge and avoiding unjustified over-precision.
-  - Put extra weight on status quo outcomes since the world usually changes slowly.
+  - Start with a reference-class base rate from historical data. Then adjust upwards or downwards based on case-specific evidence, explicitly noting the direction and strength of each adjustment.
+  - For numeric forecasts, produce a P50 that minimises symmetric absolute error. To do this, consider the historical distribution, recent trends, and the tendency of extremes to regress toward the mean. Supply P10 and P90 to express uncertainty.
   - For each adjustment — to the base rate, for cognitive/source biases, or to confidence — explicitly state the direction, magnitude, supporting evidence, and reasoning.
   - Express uncertainty using both confidence intervals and verbal probabilities (e.g., "very likely" = 85-95%)
   - Provide separate uncertainty estimates for different components (parameter uncertainty, model uncertainty, outcome uncertainty)
@@ -48,10 +49,8 @@ RESEARCH_PROMPT_TEMPLATE = ERB.new(File.read('./lib/prompt_templates/research.er
 SHARED_FORECAST_PROMPT_TEMPLATE = ERB.new(File.read('./lib/prompt_templates/shared_forecast.erb'), trim_mode: '-')
 
 BINARY_FORECAST_PROMPT = <<~BINARY_FORECAST_PROMPT
-    - A plausible scenario resulting in a No outcome. Provide a brief narrative and estimate its likelihood, explaining how it contributes to your overall probability. For the 2-3 most critical assumption, estimate how much your probability distribution would change if it were false, and provide the revised probabilities.
-    - A plausible scenario resulting in a Yes outcome. Provide a brief narrative and estimate its likelihood, explaining how it contributes to your overall probability. For the 2-3 most critical assumption, estimate how much your probability distribution would change if it were false, and provide the revised probabilities.
   - At the end of your forecast, provide a single, precise final probability in the specified format.
-    - Do not assign a probability below 5% or above 95% without extremely strong justification.
+    - You may assign any probability if supported by strong reasoning. For probabilities below 1% or above 99%, include a separate <calibration_disclaimer> explaining why the extreme value is justified.
     - Write your final prediction in this format (the percent sign is required):
   <probability>
   X%
@@ -59,9 +58,6 @@ BINARY_FORECAST_PROMPT = <<~BINARY_FORECAST_PROMPT
 BINARY_FORECAST_PROMPT
 
 NUMERIC_FORECAST_PROMPT = <<~NUMERIC_FORECAST_PROMPT
-    - The outcome if the current trend continued.
-    - A plausible scenario resulting in a low outcome. Provide a brief narrative and estimate its likelihood, explaining how it contributes to your overall probability. For the 2-3 most critical assumption, estimate how much your probability distribution would change if it were false, and provide the revised probabilities.
-    - A plausible scenario resulting in a high outcome. Provide a brief narrative and estimate its likelihood, explaining how it contributes to your overall probability. For the 2-3 most critical assumptions, estimate how much your probability distribution would change if it were false, and provide the revised probabilities.
   - At the end of your forecast, provide precise, percentile final predictions of values in the given units and range, only include the values and units, do not use ranges of values.
     - Write your final predictions in this format:
   <percentiles>
@@ -84,7 +80,6 @@ NUMERIC_FORECAST_PROMPT
 def multiple_choice_forecast_prompt(question)
   options_format = question.options.map { |opt| "#{opt}: X%" }.join("\n  ")
   <<~MULTIPLE_CHOICE_FORECAST_PROMPT
-      - A plausible scenario resulting in an unexpected outcome for each option. Provide a brief narrative and estimate its likelihood, explaining how it contributes to your overall probability. For the 2-3 most critical assumption, estimate how much your probability distribution would change if it were false, and provide the revised probabilities.
     - At the end of your forecast, provide precise, probabilistic final predictions for each option, only include the probability itself.
       - Predictions for each option must be between 0.1% and 99.9% and their sum must be 100%.
       - Write your final predictions in this format (the percent sign is required on every line):


### PR DESCRIPTION
Closes #156

## Summary

Four targeted improvements to the forecaster system prompt based on calibration review.

## Changes

### 1. Remove blanket status-quo weighting → reference-class base rate (`lib/prompts.rb`)
Replace `"Put extra weight on status quo outcomes since the world usually changes slowly."` with:
> Start with a reference-class base rate from historical data. Then adjust upwards or downwards based on case-specific evidence, explicitly noting the direction and strength of each adjustment.

### 2. Add numeric calibration guidance (`lib/prompts.rb`)
Insert into `SUPERFORECASTER_SYSTEM_PROMPT`:
> For numeric forecasts, produce a P50 that minimises symmetric absolute error. To do this, consider the historical distribution, recent trends, and the tendency of extremes to regress toward the mean. Supply P10 and P90 to express uncertainty.

### 3. Soften the 5%/95% rule (`lib/prompts.rb`, `lib/helpers/response.rb`)
- **Prompt**: Replace `"Do not assign a probability below 5% or above 95% without extremely strong justification."` with `"You may assign any probability if supported by strong reasoning. For probabilities below 1% or above 99%, include a separate <calibration_disclaimer> explaining why the extreme value is justified."`
- **Code**: Widen probability clamping in `response.rb` from `0.001/0.999` to `Aggregation::EPSILON` (1e-6) and add `calibration_disclaimer` extraction method.

### 4. Require explicit alternative scenario section (`lib/prompt_templates/shared_forecast.erb`, `lib/prompts.rb`)
- Add explicit **Alternative scenario** instruction in `shared_forecast.erb` requiring each forecaster to describe the most plausible opposite-outcome scenario, its probability, and what evidence would need to materialize.
- Simplify per-type prompts (`BINARY_FORECAST_PROMPT`, `NUMERIC_FORECAST_PROMPT`, `multiple_choice_forecast_prompt`) to drop redundant scenario bullets now covered by the shared instruction.

## Files changed

| File | Change |
|------|--------|
| `lib/prompts.rb` | 4 prompt edits (system prompt + 3 per-type prompts) |
| `lib/helpers/response.rb` | Widen clamping, add `calibration_disclaimer` extraction |
| `lib/prompt_templates/shared_forecast.erb` | Add alternative scenario instruction |
| `lib/prompt_templates/_situation_snapshot.erb` | Clarify status quo language |

## Verification

- Full test suite: 55 runs, 497 assertions, 0 failures, 0 errors
- Smoke-tested prompt text for all 4 changes (14 checks)  
- Both `Aggregation::EPSILON` clamping and `calibration_disclaimer` method verified