### PR TITLE
Blind community aggregates: two-turn forecast to prevent anchoring

### DIFF
--- a/forecast.rb
+++ b/forecast.rb
@@ -22,10 +22,62 @@ cache(post_id, "forecasts/forecast.#{forecaster_index}.json") do
   tools = provider == :perplexity ? [] : [CALCULATOR_TOOL]
   llm_args = { system: SUPERFORECASTER_SYSTEM_PROMPT, temperature: 0.9, tools: tools }
   llm = Provider.new(provider, **llm_args)
-  forecast_prompt = prompt_with_type(llm, question, SHARED_FORECAST_PROMPT_TEMPLATE)
-  cache_write(post_id, "inputs/forecast.#{forecaster_index}.md", forecast_prompt)
-  forecast = llm.eval({ 'role': 'user', 'content': forecast_prompt })
-  puts forecast.content
-  cache_write(post_id, "outputs/forecast.#{forecaster_index}.md", forecast.content)
-  forecast.to_json
+
+  # Turn 1: forecast WITHOUT community aggregates (blind estimate)
+  @include_aggregates = false
+  forecast_prompt_blind = prompt_with_type(llm, question, SHARED_FORECAST_PROMPT_TEMPLATE)
+  cache_write(post_id, "inputs/forecast.#{forecaster_index}.blind.md", forecast_prompt_blind)
+  blind_response = llm.eval({ 'role': 'user', 'content': forecast_prompt_blind })
+  cache_write(post_id, "outputs/forecast.#{forecaster_index}.blind.md", blind_response.content)
+
+  # Turn 2: show aggregates and ask for revision (skip if no aggregates exist)
+  final_response = if question.aggregate_content && !question.aggregate_content.empty?
+                     aggregate_prompt = format(AGGREGATE_REVEAL_PROMPT, aggregate_content: question.aggregate_content)
+                     cache_write(post_id, "inputs/forecast.#{forecaster_index}.aggregate.md", aggregate_prompt)
+                     final = llm.eval(
+                       { 'role': 'user', 'content': forecast_prompt_blind },
+                       { 'role': 'assistant', 'content': blind_response.content },
+                       { 'role': 'user', 'content': aggregate_prompt }
+                     )
+                     puts final.content
+                     cache_write(post_id, "outputs/forecast.#{forecaster_index}.md", final.content)
+                     final
+                   else
+                     puts blind_response.content
+                     blind_response
+                   end
+
+  # Measure anchoring delta between blind and final estimate
+  begin
+    blind_parsed = Response.new(provider, json: blind_response.to_json)
+    final_parsed = Response.new(provider, json: final_response.to_json)
+
+    delta = case question.type
+            when 'binary'
+              blind_prob = blind_parsed.probability
+              final_prob = final_parsed.probability
+              (final_prob - blind_prob).abs
+            when 'numeric', 'discrete'
+              blind_p50 = blind_parsed.percentiles[50]
+              final_p50 = final_parsed.percentiles[50]
+              # Normalize by the full range for comparability across questions
+              norm = question.upper_bound - question.lower_bound
+              norm.positive? ? ((final_p50 - blind_p50).abs / norm) : 0.0
+            when 'multiple_choice'
+              blind_probs = blind_parsed.probabilities
+              final_probs = final_parsed.probabilities
+              common_keys = blind_probs.keys & final_probs.keys
+              if common_keys.any?
+                common_keys.sum { |k| (final_probs[k] - blind_probs[k]).abs } / common_keys.size.to_f
+              else
+                0.0
+              end
+            end
+
+    cache_write(post_id, "forecasts/anchoring_delta.#{forecaster_index}.txt", delta.round(4).to_s)
+  rescue StandardError => e
+    warn "WARNING: failed to measure anchoring delta: #{e.message}"
+  end
+
+  final_response.to_json
 end

--- a/lib/prompt_templates/forecast.erb
+++ b/lib/prompt_templates/forecast.erb
@@ -27,7 +27,7 @@ Criteria for determining forecast outcome, which have not yet been met:
 <criteria>
 <%= question.criteria_content %>
 </criteria>
-<%- unless question.aggregate_content.empty? -%>
+<%- if @include_aggregates != false && !question.aggregate_content.empty? -%>
 
 Existing Metaculus Community Aggregates:
 <aggregates>

--- a/lib/prompts.rb
+++ b/lib/prompts.rb
@@ -128,6 +128,23 @@ def prompt_with_type(llm, question, prompt_template)
   prompt
 end
 
+AGGREGATE_REVEAL_PROMPT = <<~AGGREGATE_REVEAL_PROMPT
+  Your independent estimate (formed above) was made without seeing the current
+  Metaculus community forecast. Here it is:
+
+  <aggregates>
+  %<aggregate_content>s
+  </aggregates>
+
+  Does this information cause you to revise your forecast? If so, state what
+  changed, why, and provide your revised forecast in the same format as before.
+  If you maintain your original estimate, explain why the community aggregate
+  does not outweigh your independent reasoning.
+
+  IMPORTANT: Do not revise solely because the crowd disagrees. Revise only if
+  the aggregate reveals a factor or angle you genuinely hadn't considered.
+AGGREGATE_REVEAL_PROMPT
+
 CONSENSUS_SYSTEM_PROMPT = ERB.new(<<~CONSENSUS_SYSTEM_PROMPT, trim_mode: '-').result(binding)
   You are a meta-forecaster. Your role is to synthesize multiple independent superforecaster estimates into a single, well-calibrated consensus forecast.
 


### PR DESCRIPTION
## Summary

Splits the forecast prompt into two conversation turns:
1. **Blind estimate** — forecaster forms independent probability without seeing Metaculus community aggregates
2. **Aggregate reveal** — community aggregate is shown, forecaster evaluates whether to revise

Anchoring deltas are measured and cached per forecaster.

## Changes

- **`forecast.erb`**: Gate aggregate section on `@include_aggregates != false` (nil defaults to showing aggregates for backward compatibility with revise/consensus)
- **`prompts.rb`**: Add `AGGREGATE_REVEAL_PROMPT` format string for the second turn
- **`forecast.rb`**: Two-turn flow with anchoring delta measurement for all question types (binary, numeric, discrete, multiple choice)

## Backward compatibility

- `revise_forecast.rb`: Still shows aggregates (doesn't set `@include_aggregates`, which defaults to nil → shown)
- `consensus.rb`: Unaffected (uses separate template)

Closes #148