### PR TITLE
Structured revision phase: require agree/disagree statements and explicit linkage in Delphi prompt

### DIFF
--- a/lib/prompt_templates/forecast_delphi.erb
+++ b/lib/prompt_templates/forecast_delphi.erb
@@ -24,14 +24,27 @@ Update your forecast based after reviewing these forecasts from other superforec
 
 # Instructions
 
-First, complete this divergence analysis before revising anything:
-- Identify the 1-2 forecasts that diverge most from yours. For each, explicitly state:
-  a. The direction and magnitude of divergence from your estimate.
-  b. The specific evidence or reasoning that underlies their view.
-  c. Whether you considered that evidence and, if so, why you weighted it differently.
+## Part 1: Agreement/Disagreement Analysis (mandatory, before any revision)
 
-Then, based only on that analysis, decide whether to revise:
-- Update your forecast only if the divergence analysis surfaces evidence or reasoning you had not adequately considered. Do not converge toward the group median under social pressure — if your reasoning holds, maintain your position and explain why.
-- If you are moving toward the group median, explicitly state the specific epistemic reason — the evidence or argument itself, not the peer estimate — that justifies convergence.
-- If you are maintaining your position, explicitly identify the specific flaw in the most compelling dissenting forecast's reasoning.
-- Provide your revised forecast, state explicitly what changed (if anything) and why, and include your updated confidence level.
+For each peer forecast, you must:
+- List 1-2 specific elements (evidence, reasoning steps, assumptions) you **agree** with
+- List 1-2 specific elements you **disagree** with, and explain why
+
+Be specific — reference concrete claims, evidence, or reasoning steps, not vague impressions. Cover every peer forecast; do not skip any.
+
+## Part 2: Adjustment Decision (with forced linkage)
+
+Decide whether to revise your forecast based on the analysis above.
+
+**If you change your forecast:**
+- Name the specific element from a peer forecast that caused the change
+- State the direction of the change (higher or lower)
+- State the magnitude of the change
+- The change must be explicitly linked to something in the peer forecasts
+
+**If you keep your forecast the same:**
+- Name the single most compelling peer argument you considered
+- Explain specifically why you rejected it
+- Do not converge toward the group median under social pressure — if your reasoning holds, maintain your position
+
+Provide your revised forecast, state explicitly what changed (if anything) and why, and include your updated confidence level. Use the same XML format as your initial forecast.


### PR DESCRIPTION
## What

Replaces the old Instructions section in `lib/prompt_templates/forecast_delphi.erb` with a rigid two-part structure:

### Part 1: Agreement/Disagreement Analysis
- For **each** peer forecast, the model must list 1-2 elements it agrees with and 1-2 it disagrees with
- Must cover every peer forecast (no skipping)

### Part 2: Adjustment Decision (with forced linkage)
- **If changing:** must name the specific peer-forecast element, direction, and magnitude
- **If keeping same:** must name the most compelling peer argument and why it was rejected
- Anti-herding safeguard: "Do not converge toward the group median under social pressure"

## What does NOT change
- Pre-mortem section
- Forecast summary / `forecast_peer_summary`
- XML output format (parsing in `lib/response.rb` unchanged)
- `revise_forecast.rb`, `lib/utility.rb`

## Verification

Manual template test confirmed:
- ERB compiles and renders correctly
- Both Part 1 and Part 2 headers present
- Per-peer agree/disagree language verified
- Both change and stay-same linkage paths confirmed
- Pre-mortem section preserved

Closes #158