### PR TITLE
Raise revision temperature from 0.1 to 0.5 for meaningful Delphi epistemic updating

### DIFF
--- a/revise_forecast.rb
+++ b/revise_forecast.rb
@@ -19,7 +19,7 @@ provider = FORECASTERS[forecaster_index]
 
 Formatador.display "\n[bold][green]# Superforecaster[#{forecaster_index}: #{provider}]: Revising Forecast(#{post_id})…[/] "
 cache(post_id, "forecasts/revision.#{forecaster_index}.json") do
-  llm_args = { system: SUPERFORECASTER_SYSTEM_PROMPT, temperature: 0.1 }
+  llm_args = { system: SUPERFORECASTER_SYSTEM_PROMPT, temperature: 0.5 }
   llm = Provider.new(provider, **llm_args)
   forecast_prompt = prompt_with_type(llm, question, SHARED_FORECAST_PROMPT_TEMPLATE)
   forecast_delphi_prompt = FORECAST_DELPHI_PROMPT_TEMPLATE.result(binding)


### PR DESCRIPTION
Closes #145. Changes the temperature in `revise_forecast.rb` from 0.1 to 0.5 so the Delphi revision step produces meaningful epistemic updating rather than near-deterministic rubber-stamping of original forecasts.