### PR TITLE
fix: load_research returns Response object instead of string content

### DIFF
--- a/lib/utility.rb
+++ b/lib/utility.rb
@@ -224,6 +224,6 @@ def load_research(post_id, strip_tags: nil)
     tags = strip_tags.is_a?(Array) ? strip_tags : [strip_tags]
     research.stripped_content(*tags)
   else
-    research
+    research.content
   end
 end


### PR DESCRIPTION
## Problem

`load_research` returned a raw `Response` object instead of its string content when called without `strip_tags`. Callers — `shared_forecast.erb` and `summary.rb` — interpolate `@research_output` as a string, causing ERB to render `#<Response:0x...>` (Ruby's default `Object#to_s`) directly into forecast prompts.

This means the research output shown in `tmp/{post_id}/inputs/` files was the object ID, not the actual research text — breaking the research → forecast information flow.

## Fix

Changed `research` → `research.content` in the else branch of `load_research` (`lib/utility.rb:227`). This matches how every other place in the codebase handles `Response` objects (e.g. `tools_research.rb:27`, `forecast.rb:16`). The function now consistently returns a string regardless of the `strip_tags` flag.

## Verification

- `ruby -c lib/utility.rb` — syntax OK
- All callers (`forecast.rb`, `revise_forecast.rb`, `consensus.rb`, `summary.rb`) only use `@research_output` in string interpolation contexts — no callers relied on it being a Response object