### PR TITLE
Move 'Today is' into question metadata block

### DIFF
--- a/lib/metaculus.rb
+++ b/lib/metaculus.rb
@@ -421,6 +421,7 @@ class Metaculus
     def metadata_content
       @metadata_content ||= begin
         content = []
+        content << "Current Date: #{Time.now.strftime('%B %d, %Y')}"
         asked_on = Time.parse(data['created_at'])
         content << "Asked On: #{asked_on.strftime('%B %d, %Y')}"
 

--- a/lib/prompt_templates/forecast_consensus.erb
+++ b/lib/prompt_templates/forecast_consensus.erb
@@ -20,7 +20,13 @@ The forecasts above have been pooled using a calibrated mechanical aggregator (l
 </baseline>
 <%- end -%>
 
-Today is <%= Time.now.strftime('%B %d, %Y') %>.
+<%- unless question.metadata_content.empty? -%>
+
+Question Metadata:
+<metadata>
+<%= question.metadata_content %>
+</metadata>
+<%- end -%>
 
 # Instructions
 

--- a/lib/prompt_templates/shared_forecast.erb
+++ b/lib/prompt_templates/shared_forecast.erb
@@ -9,8 +9,6 @@ Here is a summary of relevant data from your research assistant (structured as f
 <%= @research_output -%>
 </research>
 
-Today is <%= Time.now.strftime('%B %d, %Y') %>.
-
 # Instructions
 
 ## Pre-Forecast Decomposition


### PR DESCRIPTION
Consolidates all temporal context into the structured `<metadata>` block.

**Changes:**
- `lib/metaculus.rb` — Adds `Current Date` as the first line of `metadata_content`, so today's date anchors the timeline before Asked On, Scheduled Resolution, etc.
- `lib/prompt_templates/shared_forecast.erb` — Removes the orphaned `Today is` line. The date now arrives via `forecast_context` → `forecast.erb` → `question.metadata_content`.
- `lib/prompt_templates/forecast_consensus.erb` — Replaces the standalone `Today is` with the full metadata block (same `<metadata>` pattern as `forecast.erb`). The consensus forecaster now has resolution dates, bounds, and current date — useful context for calibrating its synthesis against peer forecasts.