### PR TITLE
Add research_summary tag and strip from forecast prompts

### DIFF
--- a/forecast.rb
+++ b/forecast.rb
@@ -12,7 +12,7 @@ question = fetch_question(post_id)
 exit if should_skip_forecast?(question, post_id)
 
 cache_write(post_id, 'inputs/system.superforecaster.md', SUPERFORECASTER_SYSTEM_PROMPT)
-@research_output = load_research(post_id)
+@research_output = load_research(post_id, strip_tags: "research_summary")
 
 provider = FORECASTERS[forecaster_index]
 Formatador.display "\n[bold][green]# Superforecaster[#{forecaster_index}: #{provider}]: Forecasting(#{post_id})…[/] "

--- a/lib/prompt_templates/research.erb
+++ b/lib/prompt_templates/research.erb
@@ -39,3 +39,9 @@ What are simple bounds on what is plausible for the outcome?
 - For numeric questions: a range of plausible values with units.
 - Identify the main drivers of uncertainty and classify each as parameter uncertainty, model uncertainty, or outcome uncertainty.
 - Quantify the impact of the largest evidence gaps on the range (e.g. "If evidence X existed, it could shift the estimate by ±5 percentage points").
+
+After the four sections above, close your brief with a research summary in this format:
+
+<research_summary>
+[3-5 sentence executive summary covering: the base rate range found and its reliability; the 2-3 most important current indicators and their direction; the most credible surprise signal (or state that none exist); the overall uncertainty range and the single largest driver of uncertainty.]
+</research_summary>

--- a/revise_forecast.rb
+++ b/revise_forecast.rb
@@ -11,7 +11,7 @@ forecaster_index = ARGV[1]&.to_i || raise('forecaster index argv[1] is required'
 question = fetch_question(post_id)
 exit if should_skip_forecast?(question, post_id)
 
-@research_output = load_research(post_id)
+@research_output = load_research(post_id, strip_tags: "research_summary")
 @forecasts = load_forecasts(post_id, type: 'forecast')
 
 provider = FORECASTERS[forecaster_index]


### PR DESCRIPTION
## What

Adds a `<research_summary>` XML tag to the research phase output for easier and more consistent extraction, and strips it from forecast prompts where it's redundant.

## Changes

1. **`lib/prompt_templates/research.erb`** — Adds `<research_summary>` tag after the four existing sections with a 3-5 sentence executive summary format
2. **`forecast.rb`** — Strips `<research_summary>` from forecast inputs via `load_research(post_id, strip_tags: "research_summary")`
3. **`revise_forecast.rb`** — Same stripping for revision inputs

## Verification

- `<research_summary>` tag present in research output ✅
- Stripped from forecast blind input ✅
- Stripped from revision input ✅

Closes #174