### PR TITLE
Wire test_calculator.rb into test runner

### DIFF
--- a/test/run_tests.rb
+++ b/test/run_tests.rb
@@ -3,5 +3,6 @@
 
 require_relative 'test_helper'
 require_relative 'test_aggregation'
+require_relative 'test_calculator'
 require_relative 'test_continuous_cdf'
 require_relative 'test_metaculus'


### PR DESCRIPTION
## What\n\n35 calculator tests existed but were never required by `test/run_tests.rb`, so they never ran.\n\n## Change\n\nAdd `require_relative 'test_calculator'` to `test/run_tests.rb`.\n\n## Verification\n\n```\n90 runs, 536 assertions, 0 failures, 0 errors, 0 skips\nLine Coverage: 35.54% → 36.29%\n```\n\nCloses #186.