### PR TITLE
Add <forecast_summary> tag for richer comments

### DIFF
--- a/lib/prompt_templates/forecast_consensus.erb
+++ b/lib/prompt_templates/forecast_consensus.erb
@@ -5,7 +5,7 @@ Your consensus forecast will be based on the context of these forecasts from oth
 <forecasts>
 <%- @revised_forecasts.each do |forecast| -%>
 <forecast>
-<%= forecast.stripped_content('think') %>
+<%= forecast.stripped_content('think', 'forecast_summary') %>
 </forecast>
 <%- end -%>
 </forecasts>

--- a/lib/prompt_templates/forecast_delphi.erb
+++ b/lib/prompt_templates/forecast_delphi.erb
@@ -17,7 +17,7 @@ Update your forecast based after reviewing these forecasts from other superforec
 <%- @forecasts.each do |f| -%>
 <%- next if f == @forecast -%>
 <forecast>
-<%= f.stripped_content('think') %>
+<%= f.stripped_content('think', 'forecast_summary') %>
 </forecast>
 <%- end -%>
 </forecasts>

--- a/lib/prompts.rb
+++ b/lib/prompts.rb
@@ -39,6 +39,10 @@ SUPERFORECASTER_SYSTEM_PROMPT = ERB.new(<<~SUPERFORECASTER_SYSTEM_PROMPT, trim_m
   - Explain how rates might change over time.
   - Provide sensitivity analysis on key parameters.
   - Explicitly state the strongest argument against your reasoning and provide an alternative probability estimate in the same format as your main forecast, assuming that argument is correct.
+  - At the end of your forecast, before your confidence rating, provide a 1-2 sentence summary of your key argument and conclusion. Use this format:
+  <forecast_summary>
+  [One to two sentences capturing your core reasoning path and conclusion.]
+  </forecast_summary>
   - At the end of your forecast, provide a single, precise confidence rating in this format: <confidence>X%</confidence>
 SUPERFORECASTER_SYSTEM_PROMPT
 


### PR DESCRIPTION
Adds a `<forecast_summary>` tag to each forecaster's output, providing a concise 1-2 sentence key argument for the comment builder.

## Changes

- **`lib/prompts.rb`** — Added `<forecast_summary>` tag instruction to `SUPERFORECASTER_SYSTEM_PROMPT`, placed before the confidence rating instruction
- **`lib/prompt_templates/forecast_delphi.erb`** — Updated `stripped_content('think')` → `stripped_content('think', 'forecast_summary')` to strip the summary from peer forecasts (saves tokens without removing signal)
- **`lib/prompt_templates/forecast_consensus.erb`** — Same update for consensus peer forecasts

The comment builder in `lib/metaculus.rb:666` is intentionally left stripping only `think`, preserving `forecast_summary` in posted comments.

Closes #180