### PR TITLE
Cache news_summary.md in GitHub Actions workflow

### DIFF
--- a/.github/workflows/forecast.yml
+++ b/.github/workflows/forecast.yml
@@ -46,6 +46,10 @@ jobs:
         with:
           key:  tmp/${{ inputs.post_id }}/outputs/news.md
           path: tmp/${{ inputs.post_id }}/outputs/news.md
+      - uses: actions/cache/restore@v6
+        with:
+          key:  tmp/${{ inputs.post_id }}/outputs/news_summary.md
+          path: tmp/${{ inputs.post_id }}/outputs/news_summary.md
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '4.0'
@@ -64,6 +68,10 @@ jobs:
         with:
           key:  tmp/${{ inputs.post_id }}/outputs/news.md
           path: tmp/${{ inputs.post_id }}/outputs/news.md
+      - uses: actions/cache/save@v6
+        with:
+          key:  tmp/${{ inputs.post_id }}/outputs/news_summary.md
+          path: tmp/${{ inputs.post_id }}/outputs/news_summary.md
       - run: |
           echo '<details><summary>Prompt</summary>' >> $GITHUB_STEP_SUMMARY
           echo "$(cat tmp/${{ inputs.post_id }}/inputs/news.md)" >> $GITHUB_STEP_SUMMARY
@@ -71,6 +79,12 @@ jobs:
       - run: |
           echo '<details><summary>Result</summary>' >> $GITHUB_STEP_SUMMARY
           echo "$(cat tmp/${{ inputs.post_id }}/outputs/news.md)" >> $GITHUB_STEP_SUMMARY
+          echo '</details>' >> $GITHUB_STEP_SUMMARY
+      - run: |
+          echo '<details><summary>News Summary</summary>' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo "$(cat tmp/${{ inputs.post_id }}/outputs/news_summary.md)" >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
           echo '</details>' >> $GITHUB_STEP_SUMMARY
 
   research:


### PR DESCRIPTION
Add restore, save, and step summary display for `news_summary.md` in the `news` job, mirroring the existing pattern for `news.md`.

**Changes in `.github/workflows/forecast.yml`:**
- Cache restore step before `ruby/setup-ruby` (so `news.rb` skips regeneration on hit)
- Cache save step after `news.rb` completes
- Step summary `<details>` block to display the summary in the run log

Closes #190.