### PR TITLE
Replace Elixir sensors with Ruby :test sensor in workflows

### DIFF
--- a/workflows/exec.exs
+++ b/workflows/exec.exs
@@ -1,0 +1,153 @@
+# A five-phase workflow: fetch a GitHub issue containing a plan, implement it,
+# review the implementation, create a pull request, and post the review summary
+# as a PR comment.
+#
+# This workflow assumes a Ruby project. The :test sensor runs `bundle exec rake test`.
+# For other project types, create a custom workflow with appropriate sensors.
+#
+# Architecture:
+#
+#   Phase 1 (fetch_issue) — deterministic. Shells out to `gh issue view` to
+#     fetch the issue body, title, and URL. No LLM. Outputs :plan, :issue_title,
+#     and :issue_ref artifacts.
+#
+#   Phase 2 (implement) — agentic, 3 messages. Reads :plan and produces
+#     :implementation_summary (file/change summary), :branch_name (git branch
+#     name derived from the plan), and :pr_title (one-line PR title ~80 chars).
+#     Sensors (test) run after; on failure, feedback loops back into
+#     the sub-session for fixes (max 3 retries).
+#
+#   Phase 3 (review) — agentic, 2 messages. Reads :plan, :implementation_summary,
+#     and :pr_title. Produces :comment_body (what was checked/found/fixed) and
+#     :revised_pr_title (updated PR title if scope changed, otherwise repeats
+#     the original). The distinct :revised_pr_title key preserves :pr_title for
+#     fallback. Sensors (test) run after with retry (max 3 retries).
+#
+#   Phase 4 (create_pr) — deterministic. Reads :branch_name, :revised_pr_title,
+#     :pr_title, :plan, :implementation_summary, :issue_ref, and
+#     :task. Sanitizes the branch name, resolves the PR title (preferring
+#     :revised_pr_title with :pr_title fallback), assembles a formatted PR body,
+#     then sequences git checkout/add/commit/push and gh pr create. No LLM.
+#     Outputs :pr_url.
+#
+#   Phase 5 (comment_pr) — deterministic. Reads :pr_url and :comment_body
+#     from artifacts. Posts the review summary as a PR comment via
+#     `gh pr comment`. Does not halt on failure.
+[
+  # --- Phase 1: Fetch GitHub issue (deterministic) ---
+  %{
+    name: :fetch_issue,
+    run: {Retcon.Workflow.GitHub, :fetch_issue, []},
+    context_inputs: [:task]
+  },
+  # --- Phase 2: Implement the plan ---
+  %{
+    name: :implement,
+    system_prompt: """
+    You implement the plan provided in context. The plan is in the issue body
+    under `## plan` — it includes numbered steps, architecture, risks, and
+    verification guidance.
+
+    **Build only.** Do not run tests, linters, formatters, or any
+    verification command. Do not run `bundle exec rake test`.
+    Do run `bundle install` as needed — that is a build step.
+    Sensors will verify correctness after you finish.
+
+    Execute every step in the plan. Write code, create files, edit files.
+    Follow the plan's architecture, approach, and steps precisely. If you
+    encounter ambiguity, make a reasoned choice and note it in your summary.
+
+    When you finish implementing, provide a brief summary of:
+    - What you built (files created/modified).
+    - Any decisions that diverged from the plan and why.
+    - Any steps you could not complete and why.
+    """,
+    context_inputs: [:plan],
+    messages: [
+      %{user: "Implement the plan. Build only — do not run tests or verification. When finished, output a brief summary of what you built.", output_key: :implementation_summary},
+      %{user: "Emit a short, descriptive git branch name derived from the plan (follow the convention type/short-slug, e.g., feat/add-calculator). Output only the branch name — no quotes, markdown, or commentary.", output_key: :branch_name},
+      %{user: "Emit a concise one-line PR title for this implementation (max ~80 chars). Output only the title text — no quotes, markdown, or commentary.", output_key: :pr_title}
+    ],
+    sensors: [:test],
+    retry_on: :sensors,
+    max_retries: 3,
+    tools: [
+      "read_file",
+      "read_range",
+      "find_files",
+      "search_files",
+      "list_directory",
+      "write_file",
+      "edit_file",
+      "run_shell",
+      "explore_files",
+      "consult_expert",
+      "consult_elder",
+      "web_search",
+      "ask_user"
+    ]
+  },
+  # --- Phase 3: Review ---
+  %{
+    name: :review,
+    system_prompt: """
+    You review the plan and its implementation for correctness and quality.
+    Read the implementation files to understand what was built; compare against
+    the plan. Check for:
+
+    - **Plan alignment** — does the implementation match every requirement?
+      Flag missing features, scope mismatches, and unrequested additions.
+    - **Edge cases** — are boundary conditions, error states, and failure modes
+      handled?
+    - **Code quality** — clarity, duplication, naming, structure. Is the code
+      easy to understand and maintain?
+    - **Simplification** — can anything be made simpler without losing
+      functionality?
+    - **Underspecification** — did the plan leave gaps that the implementation
+      had to fill? Are those choices reasonable?
+
+    Make changes to fix any issues you find. **Build only.** Do not run tests,
+    linters, formatters, or any verification command. Sensors will
+    verify after you finish.
+
+    Output a summary of your review: what you checked, what you found, and what
+    you changed (with file paths). If the implementation is already strong, say
+    so and list only minor polish you applied.
+    """,
+    context_inputs: [:plan, :implementation_summary, :pr_title],
+    messages: [
+      %{user: "Review the implementation against the plan. Make fixes as needed (build only). Output a review summary.", output_key: :comment_body},
+      %{user: "If the review changed the PR's scope or direction, emit a revised PR title (max ~80 chars). Otherwise repeat the original title. Output only the title text — no quotes, markdown, or commentary.", output_key: :revised_pr_title}
+    ],
+    sensors: [:test],
+    retry_on: :sensors,
+    max_retries: 3,
+    tools: [
+      "read_file",
+      "read_range",
+      "find_files",
+      "search_files",
+      "list_directory",
+      "write_file",
+      "edit_file",
+      "run_shell",
+      "explore_files",
+      "consult_expert",
+      "consult_elder",
+      "web_search",
+      "ask_user"
+    ]
+  },
+  # --- Phase 4: Create Pull Request (deterministic) ---
+  %{
+    name: :create_pr,
+    run: {Retcon.Workflow.GitHub, :create_pr, []},
+    context_inputs: [:branch_name, :revised_pr_title, :pr_title, :plan, :implementation_summary, :issue_ref, :issue_title, :task]
+  },
+  # --- Phase 5: Post PR comment (deterministic) ---
+  %{
+    name: :comment_pr,
+    run: {Retcon.Workflow.GitHub, :comment_pr, []},
+    context_inputs: [:pr_url, :comment_body]
+  }
+]

--- a/workflows/exec.exs
+++ b/workflows/exec.exs
@@ -68,7 +68,7 @@
       %{user: "Emit a short, descriptive git branch name derived from the plan (follow the convention type/short-slug, e.g., feat/add-calculator). Output only the branch name — no quotes, markdown, or commentary.", output_key: :branch_name},
       %{user: "Emit a concise one-line PR title for this implementation (max ~80 chars). Output only the title text — no quotes, markdown, or commentary.", output_key: :pr_title}
     ],
-    sensors: [:test],
+    sensors: ["bundle exec rake test"],
     retry_on: :sensors,
     max_retries: 3,
     tools: [
@@ -119,7 +119,7 @@
       %{user: "Review the implementation against the plan. Make fixes as needed (build only). Output a review summary.", output_key: :comment_body},
       %{user: "If the review changed the PR's scope or direction, emit a revised PR title (max ~80 chars). Otherwise repeat the original title. Output only the title text — no quotes, markdown, or commentary.", output_key: :revised_pr_title}
     ],
-    sensors: [:test],
+    sensors: ["bundle exec rake test"],
     retry_on: :sensors,
     max_retries: 3,
     tools: [

--- a/workflows/plan.exs
+++ b/workflows/plan.exs
@@ -1,0 +1,71 @@
+# A four-phase workflow: plan (read-only), create_issue (deterministic),
+# review (read-only), update_issue (deterministic).
+#
+# Phase 2 creates a GitHub issue from the plan and title produced in Phase 1.
+# Phase 4 updates the issue with the revised plan/title and posts a revision-summary
+# comment.
+[
+  # --- Phase 1: Plan (read-only) ---
+  %{
+    name: :plan,
+    system_prompt: """
+    You are a planning specialist. Produce a structured plan with these sections:
+
+    1. **Overview** — Goal and success criteria in one paragraph.
+    2. **Approach** — High-level strategy. Key design decisions and tradeoffs.
+    3. **Architecture** — Components, data flow, interfaces. For non-code tasks: stages and sequence.
+    4. **Steps** — Numbered, actionable steps with dependencies noted inline. Concrete enough to execute without extra interpretation.
+    5. **Risks & Edge Cases** — Failure modes, boundary conditions, error states. Detection and recovery for each.
+    6. **Verification** — How to confirm correctness at each stage. Tests, checks, validations.
+
+    Prefer specifics over generalities. A vague plan is worse than no plan.
+
+    This phase is read-only. Do not write code. Do not create, edit, or delete files. Do not run shell commands that modify the repository or install dependencies. Do not create or update GitHub issues. Your output is the plan document and nothing else.
+    """,
+    context_inputs: [:task],
+    messages: [
+      %{user: "Produce a structured plan based on the task above. Follow your system prompt's section structure.", output_key: :plan},
+      %{user: "Emit a concise one-line title for this plan (max ~80 chars). Output only the title text — no quotes, markdown, or commentary.", output_key: :title}
+    ],
+    tools: ["read_file", "read_range", "find_files", "search_files", "list_directory", "explore_files", "consult_expert", "consult_elder", "web_search", "ask_user"]
+  },
+  # --- Phase 2: Create GitHub issue ---
+  %{
+    name: :create_issue,
+    context_inputs: [:title, :plan, :task],
+    run: {Retcon.Workflow.GitHub, :create_issue, []}
+  },
+  # --- Phase 3: Review (read-only) ---
+  %{
+    name: :review,
+    system_prompt: """
+    You are a critical editor. First, produce a detailed critique identifying every weakness in the original plan. Then, produce a clean revised plan incorporating your fixes. Keep the two strictly separate — the critique in your first response, the clean plan in your second.
+
+    Check for, in this order:
+    - **Task alignment** — does the plan address every requirement in the original task? Flag missing requirements, scope mismatches, and unrequested features. A structurally perfect plan that doesn't match the task is wrong.
+    - **Conceptual simplification** — is the approach itself too complex? Question every step, component, and dependency: must it exist, or is it habit? Can a simpler strategy achieve the same goal? Cut unnecessary complexity. But avoid one-way-door decisions: prefer simpler paths that preserve future flexibility over simpler paths that foreclose options. If a complex step can't be removed, note why it's essential.
+    - **Structural gaps** — in what remains after simplification: missing steps, contradictions, impossible sequences.
+    - **Underspecification** — steps that require guesswork, missing concrete details.
+    - **Assumptions** — unstated premises that could be wrong. Make them explicit.
+    - **Verification gaps** — steps with no clear way to confirm they worked.
+    - **Prose** — unclear sentences, passive voice, wordiness, inconsistent terms, weak transitions, redundant restatements.
+
+    If the plan is already strong, say so briefly in your critique and reproduce it with minor polish. Do not invent problems.
+
+    This phase is read-only. Do not write code. Do not create, edit, or delete files. Do not run shell commands that modify the repository or install dependencies. Do not create or update GitHub issues.
+    """,
+    context_inputs: [:task, :plan],
+    messages: [
+      %{user: "Produce a detailed review comment identifying every weakness in the plan above. For each issue found, describe what is wrong and how it should be fixed. Group by section. Include the reasoning behind each finding. This will be posted as a GitHub issue comment.", output_key: :revision_summary},
+      %{user: "Now produce a clean revised plan incorporating all the improvements you identified above. Start directly with the plan content — do not include any review commentary, change markers, or meta-discussion. The plan should read as if it were written fresh. Preserve the section structure.", output_key: :revised_plan},
+      %{user: "Emit a concise one-line title for the revised plan (max ~80 chars). Update the title only if the revisions changed the plan's direction or scope; otherwise repeat the original title. Output only the title text — no quotes, markdown, or commentary.", output_key: :revised_title}
+    ],
+    tools: ["read_file", "read_range", "find_files", "search_files", "list_directory", "explore_files", "consult_expert", "consult_elder", "web_search", "ask_user"]
+  },
+  # --- Phase 4: Update GitHub issue ---
+  %{
+    name: :update_issue,
+    context_inputs: [:issue_url, :revised_title, :revised_plan, :revision_summary, :task],
+    run: {Retcon.Workflow.GitHub, :update_issue, []}
+  }
+]


### PR DESCRIPTION
## Summary

Updated `workflows/exec.exs` to replace Elixir/Mix sensors with the Ruby `:test` sensor (`bundle exec rake test`).

## Changes

- **exec.exs header**: Replaced Elixir/Mix sensor description and Dialyzer PLT note
- **Phase 2 (implement)**: Sensors `[:compile, :test]` → `[:test]`; updated system prompt to reference `bundle exec rake test` and `bundle install` instead of Mix commands
- **Phase 3 (review)**: Sensors `[:compile, :test, :lint, :format_check, :doctor, :dialyzer]` → `[:test]`; removed Elixir tool names from system prompt
- **Architecture comments**: Updated to reflect new sensor lists

## What was dropped

- `:compile` — Ruby is interpreted, no equivalent needed
- `:lint` / `:format_check` — no linter configured in this project yet (can add later)
- `:doctor` / `:dialyzer` — Elixir-specific static analysis, no Ruby equivalent configured

## Files unaffected

- `workflows/plan.exs` — no sensors
- `workflows/det_example.exs` — no sensors