### PR TITLE
Replace retro prompt summaries with verbatim system prompts and templates

### DIFF
--- a/tournament_retro.rb
+++ b/tournament_retro.rb
@@ -77,23 +77,21 @@ retro_prompt = <<~RETRO_PROMPT
 
   Questions without pipeline comments use `<raw_comment>` only — analyze these using score/prediction patterns.
 
-  ## Forecaster System Prompt (all 4 forecasters)
+  ## Forecaster System Prompt (verbatim)
 
-  - Superforecaster calibration: neither overconfident nor underconfident
-  - Precise, justified numerical likelihoods with confidence intervals
-  - Weight on status quo outcomes (world changes slowly)
-  - Explicit direction/magnitude/reasoning for each base-rate adjustment
-  - Separate estimates for parameter, model, and outcome uncertainty
-  - Strongest counter-argument and alternative probability required
-  - Binary questions: floor 5%, ceiling 95% without strong justification
+  #{SUPERFORECASTER_SYSTEM_PROMPT}
 
-  ## Consensus Meta-Forecaster
+  ## Delphi Revision Prompt Template
 
-  - Synthesizes, does not re-forecast from scratch
-  - Anchors on mechanical aggregate baseline (log-odds pool with extremization)
-  - Weights by reasoning quality, not stated confidence
-  - Aware of LLM underreaction / clustering near 50% bias
-  - Identifies 2-3 largest divergences and explains which reasoning path is more sound
+  #{File.read('lib/prompt_templates/forecast_delphi.erb')}
+
+  ## Consensus Meta-Forecaster System Prompt (verbatim)
+
+  #{CONSENSUS_SYSTEM_PROMPT}
+
+  ### Consensus Meta-Forecaster Prompt Template
+
+  #{File.read('lib/prompt_templates/forecast_consensus.erb')}
 
   ## Forecast Data
 


### PR DESCRIPTION
Closes #199

## Implementation Summary

Those two matches are actually distinct headings — line 80 (`Forecaster System Prompt (verbatim)`) and line 88 (`Consensus Meta-Forecaster System Prompt (verbatim)`, which contains the first as a substring). Each heading appears exactly once.

Everything is in order. Here's the summary:

---

## Summary

**File modified**: `tournament_retro.rb`

**What was done** (three edits):

1. **Forecaster System Prompt** (line 80–82): Replaced the 7 summary bullet points (`## Forecaster System Prompt (all 4 forecasters)`) with a verbatim heading (`## Forecaster System Prompt (verbatim)`) and Ruby interpolation `#{SUPERFORECASTER_SYSTEM_PROMPT}`.

2. **Delphi Revision Prompt Template** (line 84–86): Inserted a new section between the Forecaster and Consensus sections, using `File.read('lib/prompt_templates/forecast_delphi.erb')` to inline the raw ERB template.

3. **Consensus Meta-Forecaster** (line 88–94): Replaced the 5 summary bullet points (`## Consensus Meta-Forecaster`) with a verbatim heading (`## Consensus Meta-Forecaster System Prompt (verbatim)`) interpolating `#{CONSENSUS_SYSTEM_PROMPT}`, plus a new subsection (`### Consensus Meta-Forecaster Prompt Template`) using `File.read('lib/prompt_templates/forecast_consensus.erb')`.

**Verification**:
- `ruby -c` reports `Syntax OK`
- Old bullet-point content (both sections) confirmed absent (grep returns 0)
- All four new headings present exactly once
- Untargeted sections (`Comment Data Structure`, `Forecast Data`, `extract_full_elements`) preserved unchanged
- No divergence from the plan

---

*Generated by [Retcon](https://github.com/geemus/retcon) · `deepseek-v4-pro` · Session `22c3dc37` · 2026-07-12T15:06:03.338957Z*