### PR TITLE
Fix low-base-rate underestimation with four targeted prompt improvements

### DIFF
--- a/lib/prompt_templates/shared_forecast.erb
+++ b/lib/prompt_templates/shared_forecast.erb
@@ -13,13 +13,14 @@ Here is a summary of relevant data from your research assistant (structured as f
 
 ## Pre-Forecast Decomposition
 
-Before forming your probability estimate, complete each of these five steps explicitly:
+Before forming your probability estimate, complete each of these six steps explicitly:
 
-1. **Reference class and base rate**: Identify the most relevant reference class for this question. Cite specific historical analogs or base rate data and commit to an outside-view probability before reading any question-specific evidence.
+1. **Reference class and base rate**: Identify the most relevant reference class for this question. Cite specific historical analogs or base rate data and commit to an outside-view probability before reading any question-specific evidence. Also compute the *highest* probability a well-informed forecaster could reasonably assign to this event — what constellation of evidence would justify that maximum? Reconcile the outside-view base rate with this inside-view maximum before proceeding.
 2. **Distinguishing structural factors**: What features of this specific case differ from the reference class? For each factor, state the direction (increases or decreases probability) and your estimated magnitude of adjustment from the base rate.
 3. **Resolution criteria precision**: What exactly must happen for this question to resolve in each direction? Identify any ambiguities in the resolution criteria that could affect your forecast.
 4. **Primary evidence update**: What is the single most important piece of evidence from the research that should shift the base rate? State the direction and magnitude of that adjustment. If that evidence came in unfavorably, what would your revised probability be?
 5. **Bias mechanism**: How might a specific cognitive bias be distorting the particular evidence or adjustment that most influenced your estimate — identify the structural mechanism, not just the bias name.
+6. **Discontinuity check**: What is the single strongest reason this case might *not* follow the reference class? If that reason is valid, what probability would you assign? If the gap between your main estimate and this alternative exceeds 5 percentage points, explain why the reference class still dominates. For low-base-rate events (below 10%), give this step extra weight — the cost of underestimating a rare event that occurs is typically higher than the cost of modestly overestimating one that does not.
 
 ## Forecast
 

--- a/lib/prompts.rb
+++ b/lib/prompts.rb
@@ -9,6 +9,8 @@ RESEARCHER_SYSTEM_PROMPT = ERB.new(<<~RESEARCHER_SYSTEM_PROMPT, trim_mode: '-').
   - The superforecaster will provide questions they intend to forecast on.
   - Your output must follow the four-section structured brief format described in the prompt: (1) Base Rate, (2) Current Indicators, (3) Surprise Signals, (4) Uncertainty Range. Do not add extra sections or omit any of the four.
   - Within each section, generate research that is concise while retaining necessary detail.
+  - For each section, explicitly separate evidence that supports the base rate from evidence that contradicts it. If the evidence in a section is one-sided, note this gap explicitly.
+  - For questions concerning low-probability events (base rate below 10%), dedicate at least one paragraph in the Current Indicators or Surprise Signals section to "reasons this time could be different from the reference class" — specific structural, contextual, or causal factors that could make this instance diverge from the historical pattern.
 
   - For each claim or estimate, immediately after the sentence, provide:
     a. cite the primary source ie `{Source: Metaculus (2025)}`. If a secondary source or general knowledge is used, justify why no primary source is available and flag the claim as less reliable, ie `{Less Reliable: Secondary Source}`
@@ -55,7 +57,7 @@ SHARED_FORECAST_PROMPT_TEMPLATE = ERB.new(File.read('./lib/prompt_templates/shar
 
 BINARY_FORECAST_PROMPT = <<~BINARY_FORECAST_PROMPT
   - At the end of your forecast, provide a single, precise final probability in the specified format.
-    - You may assign any probability if supported by strong reasoning. For probabilities below 1% or above 99%, include a separate <calibration_disclaimer> explaining why the extreme value is justified.
+    - You may assign any probability if supported by strong reasoning. Extreme probabilities (below 1% or above 99%) require strong evidence but should not be avoided if the evidence supports them.
     - Write your final prediction in this format (the percent sign is required):
   <probability>
   X%


### PR DESCRIPTION
## Problem

Pipeline review found three issues:
1. **Low-uncertainty binary questions**: handled reasonably well ✅
2. **Low-base-rate events that actually occur**: severely underestimated 🔴
3. **Numeric/discrete forecasts**: failing to bound properly 🔴

This PR addresses problem 2 with four targeted prompt improvements.

## Changes

### 1A. Maximum reasonable probability counterweight (`shared_forecast.erb` step 1)
Step 1 now asks forecasters to compute *both* the outside-view base rate *and* the highest reasonable inside-view probability, then reconcile them before proceeding. This prevents base-rate anchoring from dominating when case-specific evidence points higher.

### 1B. Remove calibration_disclaimer tax (`prompts.rb` BINARY_FORECAST_PROMPT)
The requirement to write a separate `<calibration_disclaimer>` for probabilities below 1% or above 99% created an asymmetric burden that discouraged well-calibrated extreme estimates. Replaced with: "Extreme probabilities require strong evidence but should not be avoided if the evidence supports them."

### 1C. Discontinuity check (`shared_forecast.erb` step 6)
New mandatory step: "What is the single strongest reason this case might NOT follow the reference class?" — producing an alternative probability and requiring explanation if the gap exceeds 5pp. For low-base-rate events, explicitly weights this higher with an asymmetric cost argument.

### 1E. Research asymmetry guidance (`prompts.rb` RESEARCHER_SYSTEM_PROMPT)
Two new rules for the research assistant:
- Every section must separate confirming vs. contradicting evidence, flagging one-sided sections
- Low-probability questions (base rate <10%) require at least one paragraph on "reasons this time could be different"

## Testing

- All 90 tests pass, 0 failures
- ERB templates compile cleanly

## Files Changed

- `lib/prompts.rb` — 3 lines added, 1 modified
- `lib/prompt_templates/shared_forecast.erb` — 3 lines added, 2 modified