### PR TITLE
Add data freshness enforcement to research phase

### DIFF
--- a/lib/prompt_templates/research.erb
+++ b/lib/prompt_templates/research.erb
@@ -2,6 +2,8 @@
 
 Your research will focus on the following forecast context.
 
+**Today's date: <%= Time.now.strftime('%B %d, %Y') %>** — all searches must use this as the reference date. Reject any data point whose observation date is unclear or unstated.
+
 <%= @forecast_prompt -%>
 
 <%= @news_output -%>
@@ -10,6 +12,8 @@ Your research will focus on the following forecast context.
 
 ## Pre-Search (private — do not include in final output)
 Decompose the forecast question into 3–5 focused sub-questions (e.g. base rates, current state, key drivers, resolution criteria edge cases). Use these as search queries to target retrieval before writing the brief. Do not output the sub-questions or raw search results.
+
+**Before writing the brief, for each current-state indicator you find, verify: (a) is this an observation or a projection? (b) what is the date of the most recent actual measurement? If you only have a projection, re-search for the observation.**
 
 ## Final Output Format (mandatory)
 Structure your research output as a brief with exactly four sections. Use the section headings exactly as shown. Do not add extra sections, preamble, or closing remarks.

--- a/lib/prompts.rb
+++ b/lib/prompts.rb
@@ -18,6 +18,17 @@ RESEARCHER_SYSTEM_PROMPT = ERB.new(<<~RESEARCHER_SYSTEM_PROMPT, trim_mode: '-').
     e. combine multiple labels using `;`, ie `{Uncertain: Lack of historical precedent and limited empirical data; Criteria Misaligned: Definitional ambiguity could introduce up to 1% error}`.
   - For repeated claims or evidence, use 'See: [Section Header]' and do not paraphrase or restate. Example: 'See: Base Rates and Historical Analogs.'
 
+  ## Data Freshness
+  - For every indicator you report, determine the date of the most recent actual measurement or observation. Distinguish between:
+    a. **Observations** — ground-truth measurements of what has already happened (e.g. "US Drought Monitor reading for July 8, 2026").
+    b. **Projections** — model forecasts of what may happen in the future (e.g. "NOAA drought outlook issued June 15, 2026, covering July–September 2026").
+  - Projections age rapidly. If the most recent data you find for an indicator is a projection:
+    a. Flag it explicitly: `{Stale: Projection issued YYYY-MM-DD; no recent observation found.}`
+    b. Search again for the most recent actual measurement — use terms like "observed," "measured," "latest reading," "as of [current month/year]."
+    c. If no observation exists yet (e.g. the event is still unfolding), note that the projection is the best available data and flag the uncertainty this introduces.
+  - For each indicator, note the observation date (not the publication date of an article referencing it). Prefer direct data sources (government monitoring, exchange data, official statistics) over news summaries.
+  - If an indicator's most recent observation is more than 2× the typical measurement interval old (e.g. weekly data that is 3+ weeks stale), flag it: `{Stale: Last observation YYYY-MM-DD, expected cadence: weekly.}`
+
   ## Market and Financial Forecasts
   - Incorporate sector trends, relevant indices, macroeconomic context, and recent news.
   - Include market sentiment, technical indicators, and recent volatility where relevant.
@@ -156,7 +167,7 @@ CONSENSUS_SYSTEM_PROMPT = ERB.new(<<~CONSENSUS_SYSTEM_PROMPT, trim_mode: '-').re
 
   - Do not preamble.
   - Your task is synthesis and adjudication, not independent forecasting from scratch. The input forecasts have already done that work — do not re-derive base rates or decompose the problem independently.
-  - Anchor on the mechanical aggregate baseline supplied with the forecasts. It pools the inputs in a calibrated way (log-odds mean for binary/multiple-choice; quantile averaging for distributions) and is the right starting point. Departures from the baseline must be justified by reasoning quality, not by raw disagreement.
+  - A mechanical aggregate baseline is supplied with the forecasts (log-odds mean for binary/multiple-choice; quantile averaging for distributions). Treat it as one input among several — it pools the raw numbers in a calibrated way, but it does not evaluate reasoning quality. Use it to orient yourself in the range of estimates, but weight reasoning quality and evidence strength above mechanical proximity.
   - Weight forecasts by both stated confidence and epistemic quality. A well-evidenced, tightly-reasoned forecast should carry more weight than a thin one even at the same confidence score.
   - Assign precise, justified numerical outputs in the exact format specified.
 CONSENSUS_SYSTEM_PROMPT

--- a/lib/tools.rb
+++ b/lib/tools.rb
@@ -13,7 +13,12 @@ SEARCH_TOOL = {
       - Provides access to information that is newer than or missing from training data.
       - Decompose complex questions into focused sub-queries for better results.
       - Prefer specific, targeted queries over broad ones.
-      - Include date context (e.g. "as of 2025") for time-sensitive topics.
+
+      # Time-Sensitive Queries
+      - Always include the current month and year in queries for time-sensitive topics (e.g. "July 2026 US Drought Monitor latest observed reading").
+      - When you need current conditions, explicitly request "observed," "measured," "latest reading," or "actual" data — not forecasts or projections.
+      - If a search returns a projection or forecast, follow up with a second search specifically for the most recent actual measurement.
+      - Prefer direct data sources (government monitoring, exchange data, official statistics) over news summaries that may reference older data.
 
       # Relevance
       - Use for current events, recent developments, or missing information.


### PR DESCRIPTION
## Problem

Recent review identified that many forecasting errors come from using stale projections (e.g., drought severity forecasts issued weeks before) without incorporating the most recent observed conditions. The research phase wasn't distinguishing between projections and actual measurements.

## Changes

Three targeted prompt/tool hardenings:

### 1. `RESEARCHER_SYSTEM_PROMPT` — new Data Freshness section
- Teaches the observation-vs-projection distinction with concrete examples
- Requires `{Stale: ...}` flagging when only projections are available
- Mandates re-search for actual measurements when only a projection is found
- Requires noting observation dates (not article publication dates)
- Adds staleness threshold based on typical measurement cadence

### 2. `SEARCH_TOOL` — hardened description
- New "Time-Sensitive Queries" section with explicit guidance
- Always include current month/year in queries
- Request "observed"/"measured"/"latest reading" — not forecasts
- Follow up with a second search if a projection is returned
- Prefer direct data sources over news summaries

### 3. `research.erb` — date banner + pre-search verification
- Prominent `Today's date` banner at the top of the research prompt
- Pre-search step requiring verification: (a) observation or projection? (b) what's the measurement date?

All three changes are prompt-only — no code logic changes, no API changes.