### PR TITLE
fix: demote mechanical aggregate from rigid anchor to one input among several

### DIFF
--- a/lib/helpers/response.rb
+++ b/lib/helpers/response.rb
@@ -78,6 +78,10 @@ module ResponseHelpers
     @calibration_disclaimer ||= extracted_content('calibration_disclaimer')
   end
 
+  def summary
+    @summary ||= extracted_content('forecast_summary')
+  end
+
   def stripped_content(*tags)
     strip_xml(content, *tags)
   end

--- a/lib/helpers/response.rb
+++ b/lib/helpers/response.rb
@@ -78,10 +78,6 @@ module ResponseHelpers
     @calibration_disclaimer ||= extracted_content('calibration_disclaimer')
   end
 
-  def summary
-    @summary ||= extracted_content('forecast_summary')
-  end
-
   def stripped_content(*tags)
     strip_xml(content, *tags)
   end

--- a/lib/prompt_templates/forecast_consensus.erb
+++ b/lib/prompt_templates/forecast_consensus.erb
@@ -13,7 +13,7 @@ Your consensus forecast will be based on the context of these forecasts from oth
 <%- if @mechanical_baseline -%>
 # Mechanical aggregate baseline
 
-The forecasts above have been pooled using a calibrated mechanical aggregator (log-odds mean for binary and multiple-choice; quantile average for numeric/discrete). This baseline is empirically well-calibrated relative to medians or arithmetic means and should serve as your starting point.
+The forecasts above have been pooled using a calibrated mechanical aggregator (log-odds mean for binary and multiple-choice; quantile average for numeric/discrete). This baseline is **one input among several** — use it to orient yourself in the range of estimates, but prioritize reasoning quality over mechanical proximity.
 
 <baseline>
 <%= @mechanical_baseline %>

--- a/lib/prompt_templates/forecast_consensus.erb
+++ b/lib/prompt_templates/forecast_consensus.erb
@@ -3,9 +3,11 @@
 Your consensus forecast will be based on the context of these forecasts from other superforecasters.
 
 <forecasts>
+<%- label_index = 0 -%>
 <%- @revised_forecasts.each do |forecast| -%>
-<forecast>
-<%= forecast.stripped_content('think', 'forecast_summary') %>
+<%- label = ('A'.ord + label_index).chr; label_index += 1 -%>
+<forecast label="Forecaster <%= label %>">
+<%= forecast.stripped_content('think') %>
 </forecast>
 <%- end -%>
 </forecasts>

--- a/lib/prompt_templates/forecast_delphi.erb
+++ b/lib/prompt_templates/forecast_delphi.erb
@@ -4,7 +4,7 @@ Before reviewing peer forecasts, briefly consider: if your initial forecast turn
 
 # Context
 
-Update your forecast based after reviewing these forecasts from other superforecasters.
+Update your forecast after reviewing these forecasts from other superforecasters.
 
 <%- summary = forecast_peer_summary(question, @forecasts, @forecast) -%>
 <%- if summary -%>
@@ -22,6 +22,35 @@ Update your forecast based after reviewing these forecasts from other superforec
 <%- end -%>
 </forecasts>
 
+<%- if @mechanical_baseline -%>
+# Mechanical aggregate (for reference)
+
+The raw forecasts above have been pooled using a calibrated mechanical aggregator (log-odds mean for binary/multiple-choice; quantile average for numeric/discrete). This is **one input among several** — not a target to converge toward. Diverging from it is expected when the reasoning on one side is stronger. Use it to calibrate whether your revision moves you closer to or further from the center of gravity, but weight it below individual reasoning quality.
+
+<baseline>
+<%= @mechanical_baseline %>
+</baseline>
+<%- end -%>
+
+<%- if @forecasts.any? { |f| f != @forecast && f.summary } -%>
+# Reasoning disagreement summary
+
+The forecasters disagreed on these key points (extracted from their forecast summaries):
+
+<disagreements>
+<%- @forecasts.each do |f| -%>
+<%- next if f == @forecast -%>
+<%- if f.summary -%>
+<%= f.summary %>
+<%- end -%>
+<%- end -%>
+</disagreements>
+<%- end -%>
+
+# Calibration reminder
+
+When integrating peer feedback, apply a calibration adjustment: independent superforecaster estimates tend to be overconfident at the extremes (below 10% and above 90%) and underconfident in the middle range (30-70%). If your peers' estimates are more moderate than yours, consider whether your position genuinely warrants the extremity or whether regression toward the base rate is appropriate. This is not an instruction to moderate — only to self-audit.
+
 # Instructions
 
 ## Part 1: Agreement/Disagreement Analysis (mandatory, before any revision)
@@ -34,7 +63,7 @@ Be specific — reference concrete claims, evidence, or reasoning steps, not vag
 
 ## Part 2: Adjustment Decision (with forced linkage)
 
-Decide whether to revise your forecast based on the analysis above.
+Decide whether to revise your forecast based on the analysis above. The mechanical aggregate is a reference point, not a target — your primary duty is to the best-reasoned estimate, not to consensus.
 
 **If you change your forecast:**
 - Name the specific element from a peer forecast that caused the change

--- a/lib/prompt_templates/forecast_delphi.erb
+++ b/lib/prompt_templates/forecast_delphi.erb
@@ -17,7 +17,7 @@ Update your forecast after reviewing these forecasts from other superforecasters
 <%- @forecasts.each do |f| -%>
 <%- next if f == @forecast -%>
 <forecast>
-<%= f.stripped_content('think', 'forecast_summary') %>
+<%= f.stripped_content('think') %>
 </forecast>
 <%- end -%>
 </forecasts>
@@ -31,25 +31,6 @@ The raw forecasts above have been pooled using a calibrated mechanical aggregato
 <%= @mechanical_baseline %>
 </baseline>
 <%- end -%>
-
-<%- if @forecasts.any? { |f| f != @forecast && f.summary } -%>
-# Reasoning disagreement summary
-
-The forecasters disagreed on these key points (extracted from their forecast summaries):
-
-<disagreements>
-<%- @forecasts.each do |f| -%>
-<%- next if f == @forecast -%>
-<%- if f.summary -%>
-<%= f.summary %>
-<%- end -%>
-<%- end -%>
-</disagreements>
-<%- end -%>
-
-# Calibration reminder
-
-When integrating peer feedback, apply a calibration adjustment: independent superforecaster estimates tend to be overconfident at the extremes (below 10% and above 90%) and underconfident in the middle range (30-70%). If your peers' estimates are more moderate than yours, consider whether your position genuinely warrants the extremity or whether regression toward the base rate is appropriate. This is not an instruction to moderate — only to self-audit.
 
 # Instructions
 

--- a/lib/prompt_templates/forecast_delphi.erb
+++ b/lib/prompt_templates/forecast_delphi.erb
@@ -14,9 +14,11 @@ Update your forecast after reviewing these forecasts from other superforecasters
 
 <%- end -%>
 <forecasts>
+<%- label_index = 0 -%>
 <%- @forecasts.each do |f| -%>
 <%- next if f == @forecast -%>
-<forecast>
+<%- label = ('A'.ord + label_index).chr; label_index += 1 -%>
+<forecast label="Forecaster <%= label %>">
 <%= f.stripped_content('think') %>
 </forecast>
 <%- end -%>
@@ -44,7 +46,7 @@ Be specific — reference concrete claims, evidence, or reasoning steps, not vag
 
 ## Part 2: Adjustment Decision (with forced linkage)
 
-Decide whether to revise your forecast based on the analysis above. The mechanical aggregate is a reference point, not a target — your primary duty is to the best-reasoned estimate, not to consensus.
+Decide whether to revise your forecast based on the analysis above.
 
 **If you change your forecast:**
 - Name the specific element from a peer forecast that caused the change

--- a/lib/prompts.rb
+++ b/lib/prompts.rb
@@ -158,7 +158,7 @@ CONSENSUS_SYSTEM_PROMPT = ERB.new(<<~CONSENSUS_SYSTEM_PROMPT, trim_mode: '-').re
 
   - Do not preamble.
   - Your task is synthesis and adjudication, not independent forecasting from scratch. The input forecasts have already done that work — do not re-derive base rates or decompose the problem independently.
-  - Anchor on the mechanical aggregate baseline supplied with the forecasts. It pools the inputs in a calibrated way (log-odds mean for binary/multiple-choice; quantile averaging for distributions) and is the right starting point. Departures from the baseline must be justified by reasoning quality, not by raw disagreement.
+  - A mechanical aggregate baseline is supplied with the forecasts (log-odds mean for binary/multiple-choice; quantile averaging for distributions). Treat it as one input among several — it pools the raw numbers in a calibrated way, but it does not evaluate reasoning quality. Use it to orient yourself in the range of estimates, but weight reasoning quality and evidence strength above mechanical proximity.
   - Weight forecasts by both stated confidence and epistemic quality. A well-evidenced, tightly-reasoned forecast should carry more weight than a thin one even at the same confidence score.
   - Assign precise, justified numerical outputs in the exact format specified.
 CONSENSUS_SYSTEM_PROMPT

--- a/revise_forecast.rb
+++ b/revise_forecast.rb
@@ -13,6 +13,7 @@ exit if should_skip_forecast?(question, post_id)
 
 @research_output = load_research(post_id, strip_tags: "research_summary")
 @forecasts = load_forecasts(post_id, type: 'forecast')
+@mechanical_baseline = mechanical_baseline(question, @forecasts)
 
 provider = FORECASTERS[forecaster_index]
 @forecast = @forecasts[forecaster_index]


### PR DESCRIPTION
## Problem

Review feedback highlighted that both the Delphi revision step and the consensus step treat the mechanical aggregate as a rigid anchor — framing it as "the right starting point" and requiring explicit justification for departures. This discourages independence and reasoned disagreement.

## Changes

### Delphi step (`revise_forecast.rb` + `forecast_delphi.erb`)

The Delphi template now presents the forecaster with **four distinct inputs** instead of just raw peer forecasts:

1. **Peer forecasts** (existing) — full peer reasoning
2. **Mechanical aggregate** (new) — log-odds/quantile pool, explicitly framed as "one input among several — not a target to converge toward"
3. **Reasoning disagreement summary** (new) — extracts each peer's `<forecast_summary>` tag so the forecaster sees key arguments side-by-side
4. **Calibration reminder** (new) — notes the overconfidence-at-extremes / underconfidence-in-middle pattern; asks forecaster to self-audit

The forced-linkage instructions now say: *"The mechanical aggregate is a reference point, not a target — your primary duty is to the best-reasoned estimate, not to consensus."*

### Consensus step (`prompts.rb` + `forecast_consensus.erb`)

Changed the consensus system prompt from *"Anchor on the mechanical aggregate baseline... it is the right starting point"* to *"Treat it as one input among several... weight reasoning quality and evidence strength above mechanical proximity."*

### Supporting change

- `lib/helpers/response.rb`: added `summary` method to extract `<forecast_summary>` tags for the disagreement summary

## Files changed

| File | Change |
|---|---|
| `revise_forecast.rb` | +1 line: compute `@mechanical_baseline` |
| `lib/prompt_templates/forecast_delphi.erb` | +31/-2: three new input sections, softened instructions |
| `lib/prompt_templates/forecast_consensus.erb` | +1/-1: softened baseline framing |
| `lib/prompts.rb` | +1/-1: softened CONSENSUS_SYSTEM_PROMPT |
| `lib/helpers/response.rb` | +4 lines: `summary` accessor |