### PR TITLE
Downgrade provider models to Sonnet/GPT-4.1-mini/sonar-pro and reduce consensus effort to medium

### DIFF
--- a/consensus.rb
+++ b/consensus.rb
@@ -20,7 +20,7 @@ begin
   provider = :anthropic
   Formatador.display "\n[bold][green]# Superforecaster: Summarizing Consensus(#{post_id})…[/] "
   consensus_json = cache(post_id, 'forecasts/consensus.json') do
-    llm = Provider.new(provider, system: CONSENSUS_SYSTEM_PROMPT, reasoning: { effort: 'high' }, tools: [CALCULATOR_TOOL])
+    llm = Provider.new(provider, system: CONSENSUS_SYSTEM_PROMPT, reasoning: { effort: 'medium' }, tools: [CALCULATOR_TOOL])
     consensus_prompt = consensus_prompt_with_type(llm, question, FORECAST_CONSENSUS_PROMPT_TEMPLATE)
     cache_write(post_id, 'inputs/consensus.md', consensus_prompt)
     consensus = llm.eval({ 'role': 'user', 'content': consensus_prompt })

--- a/lib/perplexity.rb
+++ b/lib/perplexity.rb
@@ -7,7 +7,7 @@ class Perplexity
   attr_accessor :model, :system, :temperature, :tools
 
   def initialize(
-    model: 'sonar-reasoning-pro',
+    model: 'sonar-pro',
     system: RESEARCHER_SYSTEM_PROMPT,
     temperature: 0.1,
     tools: []

--- a/lib/provider.rb
+++ b/lib/provider.rb
@@ -30,9 +30,9 @@ module Provider
 
       case provider_symbol
       when :anthropic
-        args[:model] ||= 'anthropic/claude-opus-4.8'
+        args[:model] ||= 'anthropic/claude-sonnet-4.5'
       when :openai
-        args[:model] ||= 'openai/gpt-5.4'
+        args[:model] ||= 'openai/gpt-4.1-mini'
         args[:api_key] ||= ENV['OPEN_ROUTER_OPENAI_API_KEY'] || ENV['OPEN_ROUTER_API_KEY']
       end
 


### PR DESCRIPTION
Closes #213

## Implementation Summary

All four changes are now confirmed in place. Here's a summary:

## What was built

**Files modified (4 changes across 3 files):**

| File | Change | Line |
|---|---|---|
| `lib/provider.rb` | Anthropic default: `claude-opus-4.8` → `claude-sonnet-4.5` | 33 |
| `lib/provider.rb` | OpenAI default: `gpt-5.4` → `gpt-4.1-mini` | 35 |
| `lib/perplexity.rb` | Perplexity default: `sonar-reasoning-pro` → `sonar-pro` | 10 |
| `consensus.rb` | Consensus reasoning effort: `high` → `medium` | 23 |

**What these changes affect:**
- `forecast.rb` and `revise_forecast.rb` pick up the downgraded Anthropic/OpenAI/Perplexity models automatically via `Provider.new` — no code changes needed there.
- `consensus.rb` now uses `medium` reasoning effort (matching `OpenRouter`'s constructor default) with the downgraded Anthropic model.
- `tools_research.rb` is untouched — it continues using `anthropic/claude-opus-4.8` with `high` effort via direct `OpenRouter.new` instantiation.
- `summary.rb` and `tournament_retro.rb` are untouched — they use `:deepseek` which was already on `deepseek-v4-pro`.

---

*Generated by [Retcon](https://github.com/geemus/retcon) · `deepseek-v4-pro` · Session `387a52b0` · 2026-07-27T19:38:56.398468Z*