### PR TITLE
fix: add calculator encouragement, obs/projection gate, and source priority to research prompts

### DIFF
--- a/lib/prompt_templates/research.erb
+++ b/lib/prompt_templates/research.erb
@@ -15,6 +15,22 @@ Decompose the forecast question into 3–5 focused sub-questions (e.g. base rate
 
 **Before writing the brief, for each current-state indicator you find, verify: (a) is this an observation or a projection? (b) what is the date of the most recent actual measurement? If you only have a projection, re-search for the observation.**
 
+## Calculator Tool
+You have access to a `calculate` tool for safe arithmetic. **Use it whenever you encounter:**
+- Compounding (e.g. cumulative probability over N years: `1 - (1 - r)^N`)
+- Expected values or Bayes updates
+- Any computation with more than two numbers or more than one operation
+- Normalization or log-odds conversions
+If you find yourself typing a number you derived from other numbers in your head, use the tool instead.
+
+## Observation / Projection Gate
+**For every indicator in Section 2, you MUST label it as either:**
+- `{Observation: YYYY-MM-DD}` — a measurement of something that already happened
+- `{Projection: issued YYYY-MM-DD, covering YYYY-MM-DD to YYYY-MM-DD}` — a model forecast
+- `{Stale: Last observation YYYY-MM-DD, expected cadence: [weekly/monthly/etc.]}` — overdue
+
+If you cannot determine which category an indicator falls into, it is a projection — flag it as such. Do not present projections as observations.
+
 ## Final Output Format (mandatory)
 Structure your research output as a brief with exactly four sections. Use the section headings exactly as shown. Do not add extra sections, preamble, or closing remarks.
 

--- a/lib/prompts.rb
+++ b/lib/prompts.rb
@@ -31,6 +31,12 @@ RESEARCHER_SYSTEM_PROMPT = ERB.new(<<~RESEARCHER_SYSTEM_PROMPT, trim_mode: '-').
   - For each indicator, note the observation date (not the publication date of an article referencing it). Prefer direct data sources (government monitoring, exchange data, official statistics) over news summaries.
   - If an indicator's most recent observation is more than 2× the typical measurement interval old (e.g. weekly data that is 3+ weeks stale), flag it: `{Stale: Last observation YYYY-MM-DD, expected cadence: weekly.}`
 
+  ## Source Priority
+  - The news articles provided with the question are a *starting point*, not authoritative.
+  - When a claim from a provided article is central to your analysis, verify it via web_search against a primary source (government data, official statistics, peer-reviewed research, or direct exchange/market data).
+  - If verification fails or the primary source contradicts the article, report the primary source and note the discrepancy.
+  - Prefer direct data sources over news summaries. A minor claim from a primary source is worth more than a major claim from an unverifiable article.
+
   ## Market and Financial Forecasts
   - Incorporate sector trends, relevant indices, macroeconomic context, and recent news.
   - Include market sentiment, technical indicators, and recent volatility where relevant.


### PR DESCRIPTION
## What

Three prompt-level improvements to the research phase:

1. **Calculator encouragement** — tells the model when to use the `calculate` tool (compounding, Bayes, normalization, log-odds) instead of mental arithmetic
2. **Observation/projection gate** — requires every Section 2 indicator to carry an explicit `{Observation: YYYY-MM-DD}`, `{Projection: issued ...}`, or `{Stale: ...}` label
3. **Source priority** — deprioritizes provided news articles vs. primary source verification via web search

## Why

Addresses findings from a research output review (Q578):

- Hand-wavy numbers like "~11% reduction" and "4–10% century totals" should be computed precisely
- AI timeline projections presented as observations without any flag
- Low-quality news sources (Russian tabloids) anchoring the research when primary data exists
- Research had access to a `calculate` tool but never used it