### PR TITLE
Fix parsing of multiple-choice options containing colons

### DIFF
--- a/lib/helpers/response.rb
+++ b/lib/helpers/response.rb
@@ -49,7 +49,7 @@ module ResponseHelpers
       extracted_content('probabilities').split("\n").each do |line|
         line = line.strip
         next if line.empty?
-        key, value = line.split(': ', 2)
+        key, value = line.rpartition(': ').values_at(0, 2)
         probabilities[key.strip] = parse_probability(value)
       end
       probabilities


### PR DESCRIPTION
When an option name contains a colon (e.g. "Spider-Man: Brand New Day"), the previous `split(': ', 2)` incorrectly split on the first colon, truncating the option name and producing a malformed forecast payload.

Switch to `rpartition(': ')` which splits on the last colon, preserving colons within option names while correctly separating the key from the probability value.

**Before:** `"Spider-Man: Brand New Day: 3%"` → `{"Spider-Man" => 0.0}` ❌
**After:** `"Spider-Man: Brand New Day: 3%"` → `{"Spider-Man: Brand New Day" => 0.03}` ✅